### PR TITLE
Implement equality testing for classes with _ptr pointers

### DIFF
--- a/wlroots/__init__.py
+++ b/wlroots/__init__.py
@@ -9,3 +9,11 @@ __wlroots_version__ = "{}.{}.{}".format(
 )
 
 __version__ = "0.2.3"
+
+
+class Ptr:
+    def __eq__(self, other):
+        return hasattr(other, "_ptr") and self._ptr == other._ptr
+
+    def __hash__(self):
+        return id(self)

--- a/wlroots/backend.py
+++ b/wlroots/backend.py
@@ -4,13 +4,13 @@ import weakref
 
 from pywayland.server import Display, Signal
 
-from . import ffi, lib
+from . import ffi, lib, Ptr
 from wlroots.util.log import logger
 from wlroots.wlr_types.input_device import InputDevice
 from wlroots.wlr_types.output import Output
 
 
-class Backend:
+class Backend(Ptr):
     def __init__(self, display: Display) -> None:
         """Create a backend to interact with a Wayland display
 

--- a/wlroots/renderer.py
+++ b/wlroots/renderer.py
@@ -4,14 +4,14 @@ from typing import Any, List, Tuple, Union
 
 from pywayland.server import Display
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from wlroots.backend import Backend
 from wlroots.wlr_types import Box, Matrix, Texture
 
 ColorType = Union[List, Tuple, ffi.CData]
 
 
-class Renderer:
+class Renderer(Ptr):
     def __init__(self, backend: Backend, display: Display) -> None:
         """Obtains the renderer this backend is using
 

--- a/wlroots/util/clock.py
+++ b/wlroots/util/clock.py
@@ -1,9 +1,9 @@
 # Copyright Sean Vig (c) 2020
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 
 
-class Timespec:
+class Timespec(Ptr):
     def __init__(self, ptr) -> None:
         """A wrapper aronud a timespec struct"""
         self._ptr = ptr

--- a/wlroots/wlr_types/compositor.py
+++ b/wlroots/wlr_types/compositor.py
@@ -3,13 +3,13 @@
 from pywayland.server import Display
 from typing import TYPE_CHECKING
 
-from wlroots import lib
+from wlroots import lib, Ptr
 
 if TYPE_CHECKING:
     from wlroots.renderer import Renderer  # noqa: F401
 
 
-class Compositor:
+class Compositor(Ptr):
     def __init__(self, display: Display, renderer: "Renderer") -> None:
         """A compositor for clients to be able to allocate surfaces
 

--- a/wlroots/wlr_types/cursor.py
+++ b/wlroots/wlr_types/cursor.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 
 from pywayland.server import Signal
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from .input_device import InputDevice, InputDeviceType
 from .output_layout import OutputLayout
 from .pointer import (
@@ -29,7 +29,7 @@ class WarpMode(enum.Enum):
     AbsoluteClosest = enum.auto()
 
 
-class Cursor:
+class Cursor(Ptr):
     def __init__(self, output_layout: OutputLayout) -> None:
         """Manage a cursor attached to the given output layout
 

--- a/wlroots/wlr_types/data_device_manager.py
+++ b/wlroots/wlr_types/data_device_manager.py
@@ -2,10 +2,10 @@
 
 from pywayland.server import Display
 
-from wlroots import lib
+from wlroots import lib, Ptr
 
 
-class DataDeviceManager:
+class DataDeviceManager(Ptr):
     def __init__(self, display: Display) -> None:
         """Data manager to handle the clipboard
 

--- a/wlroots/wlr_types/input_device.py
+++ b/wlroots/wlr_types/input_device.py
@@ -4,7 +4,7 @@ import enum
 import weakref
 
 from .keyboard import Keyboard
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 
 _weakkeydict: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
@@ -25,7 +25,7 @@ class InputDeviceType(enum.IntEnum):
     SWITCH = lib.WLR_INPUT_DEVICE_SWITCH
 
 
-class InputDevice:
+class InputDevice(Ptr):
     def __init__(self, ptr) -> None:
         """Create the input device from the given cdata
 

--- a/wlroots/wlr_types/keyboard.py
+++ b/wlroots/wlr_types/keyboard.py
@@ -6,7 +6,7 @@ from weakref import WeakKeyDictionary
 from pywayland.server import Signal
 from pywayland.protocol.wayland import WlKeyboard
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 
 _weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
 
@@ -30,7 +30,7 @@ class KeyboardModifier(enum.IntFlag):
     MOD5 = lib.WLR_MODIFIER_MOD5
 
 
-class KeyboardKeyEvent:
+class KeyboardKeyEvent(Ptr):
     def __init__(self, ptr) -> None:
         """Event that a key has been pressed or release
 
@@ -60,7 +60,7 @@ class KeyboardKeyEvent:
         return WlKeyboard.key_state(self._ptr.state)
 
 
-class Keyboard:
+class Keyboard(Ptr):
     def __init__(self, ptr) -> None:
         """The Keyboard wlroots object
 
@@ -119,7 +119,7 @@ class Keyboard:
         return KeyboardModifier(modifiers)
 
 
-class KeyboardModifiers:
+class KeyboardModifiers(Ptr):
     def __init__(self, ptr) -> None:
         """Modifiers of a given keyboard
 

--- a/wlroots/wlr_types/matrix.py
+++ b/wlroots/wlr_types/matrix.py
@@ -2,11 +2,11 @@
 
 from pywayland.protocol.wayland import WlOutput
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from .box import Box
 
 
-class Matrix:
+class Matrix(Ptr):
     def __init__(self, ptr) -> None:
         """A matrix which encodes transformations used for rendering"""
         self._ptr = ptr

--- a/wlroots/wlr_types/output.py
+++ b/wlroots/wlr_types/output.py
@@ -5,11 +5,11 @@ from typing import Tuple, Optional
 from pywayland.server import Signal
 from pywayland.protocol.wayland import WlOutput
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from .matrix import Matrix
 
 
-class Output:
+class Output(Ptr):
     def __init__(self, ptr) -> None:
         """A compositor output region
 
@@ -155,7 +155,7 @@ class Output:
         return WlOutput.transform(lib.wlr_output_transform_invert(transform))
 
 
-class OutputMode:
+class OutputMode(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ptr
 

--- a/wlroots/wlr_types/output_layout.py
+++ b/wlroots/wlr_types/output_layout.py
@@ -2,11 +2,11 @@
 
 from typing import Tuple
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from .output import Output
 
 
-class OutputLayout:
+class OutputLayout(Ptr):
     def __init__(self) -> None:
         """Creates an output layout to work with a layout of screens
 

--- a/wlroots/wlr_types/pointer.py
+++ b/wlroots/wlr_types/pointer.py
@@ -2,7 +2,7 @@
 
 import enum
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from .input_device import ButtonState, InputDevice
 
 
@@ -20,7 +20,7 @@ class AxisOrientation(enum.IntEnum):
     HORIZONTAL = lib.WLR_AXIS_ORIENTATION_HORIZONTAL
 
 
-class PointerEventMotion:
+class PointerEventMotion(Ptr):
     def __init__(self, ptr) -> None:
         """A relative motion pointer event
 
@@ -55,7 +55,7 @@ class PointerEventMotion:
         return self._ptr.unaccel_dy
 
 
-class PointerEventMotionAbsolute:
+class PointerEventMotionAbsolute(Ptr):
     def __init__(self, ptr) -> None:
         """A absolute motion pointer event
 
@@ -84,7 +84,7 @@ class PointerEventMotionAbsolute:
         return self._ptr.y
 
 
-class PointerEventButton:
+class PointerEventButton(Ptr):
     def __init__(self, ptr) -> None:
         """A pointer button event
 
@@ -111,7 +111,7 @@ class PointerEventButton:
         return ButtonState(self._ptr.state)
 
 
-class PointerEventAxis:
+class PointerEventAxis(Ptr):
     def __init__(self, ptr) -> None:
         """A pointer axis event
 
@@ -146,37 +146,37 @@ class PointerEventAxis:
         return self._ptr.delta_discrete
 
 
-class PointerEventSwipeBegin:
+class PointerEventSwipeBegin(Ptr):
     def __init__(self, ptr) -> None:
         ptr = ffi.cast("struct wlr_event_pointer_swipe_begin *", ptr)
         self._ptr = ptr
 
 
-class PointerEventSwipeUpdate:
+class PointerEventSwipeUpdate(Ptr):
     def __init__(self, ptr) -> None:
         ptr = ffi.cast("struct wlr_event_pointer_swipe_update *", ptr)
         self._ptr = ptr
 
 
-class PointerEventSwipeEnd:
+class PointerEventSwipeEnd(Ptr):
     def __init__(self, ptr) -> None:
         ptr = ffi.cast("struct wlr_event_pointer_swipe_end *", ptr)
         self._ptr = ptr
 
 
-class PointerEventPinchBegin:
+class PointerEventPinchBegin(Ptr):
     def __init__(self, ptr) -> None:
         ptr = ffi.cast("struct wlr_event_pointer_pinch_begin *", ptr)
         self._ptr = ptr
 
 
-class PointerEventPinchUpdate:
+class PointerEventPinchUpdate(Ptr):
     def __init__(self, ptr) -> None:
         ptr = ffi.cast("struct wlr_event_pointer_pinch_update *", ptr)
         self._ptr = ptr
 
 
-class PointerEventPinchEnd:
+class PointerEventPinchEnd(Ptr):
     def __init__(self, ptr) -> None:
         ptr = ffi.cast("struct wlr_event_pointer_pinch_end *", ptr)
         self._ptr = ptr

--- a/wlroots/wlr_types/seat.py
+++ b/wlroots/wlr_types/seat.py
@@ -6,7 +6,7 @@ from weakref import WeakKeyDictionary
 from pywayland.server import Display, Signal
 from pywayland.protocol.wayland import WlSeat
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from .input_device import ButtonState, InputDevice
 from .keyboard import Keyboard, KeyboardModifiers, KeyboardKeyEvent
 from .pointer import AxisSource, AxisOrientation
@@ -15,7 +15,7 @@ from .surface import Surface
 _weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
 
 
-class KeyboardGrab:
+class KeyboardGrab(Ptr):
     def __init__(self, seat: "Seat") -> None:
         """Setup the keyboard grab"""
         self._ptr = ffi.new("struct wlr_seat_keyboard_grab *")
@@ -31,7 +31,7 @@ class KeyboardGrab:
         lib.wlr_seat_keyboard_end_grab(self._seat)
 
 
-class Seat:
+class Seat(Ptr):
     def __init__(self, display: Display, name: str) -> None:
         """Allocates a new seat and adds a seat global to the display
 
@@ -280,7 +280,7 @@ class Seat:
         self.destroy()
 
 
-class PointerRequestSetCursorEvent:
+class PointerRequestSetCursorEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_seat_pointer_request_set_cursor_event *", ptr)
 
@@ -300,7 +300,7 @@ class PointerRequestSetCursorEvent:
         return self._ptr.hotspot_x, self._ptr.hotspot_y
 
 
-class RequestSetSelectionEvent:
+class RequestSetSelectionEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_seat_request_set_selection_event *", ptr)
 
@@ -311,7 +311,7 @@ class RequestSetSelectionEvent:
         return self._ptr.serial
 
 
-class RequestSetPrimarySelectionEvent:
+class RequestSetPrimarySelectionEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_seat_request_set_selection_event *", ptr)
 
@@ -322,28 +322,28 @@ class RequestSetPrimarySelectionEvent:
         return self._ptr.serial
 
 
-class RequestStartDragEvent:
+class RequestStartDragEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_seat_request_start_drag_event *", ptr)
 
     # TODO
 
 
-class PointerFocusChangeEvent:
+class PointerFocusChangeEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_seat_pointer_focus_change_event *", ptr)
 
     # TODO
 
 
-class KeyboardFocusChangeEvent:
+class KeyboardFocusChangeEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_seat_keyboard_focus_change_event *", ptr)
 
     # TODO
 
 
-class SeatPointerState:
+class SeatPointerState(Ptr):
     def __init__(self, ptr) -> None:
         """The current state of the pointer on the seat"""
         self._ptr = ptr
@@ -362,7 +362,7 @@ class SeatPointerState:
         return Surface(focused_surface)
 
 
-class SeatKeyboardState:
+class SeatKeyboardState(Ptr):
     def __init__(self, ptr) -> None:
         """The current state of the keyboard on the seat"""
         self._ptr = ptr

--- a/wlroots/wlr_types/surface.py
+++ b/wlroots/wlr_types/surface.py
@@ -5,14 +5,14 @@ from weakref import WeakKeyDictionary
 from pywayland.protocol.wayland import WlOutput
 from pywayland.server import Signal
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from wlroots.util.clock import Timespec
 from .texture import Texture
 
 _weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
 
 
-class Surface:
+class Surface(Ptr):
     def __init__(self, ptr):
         """Create a wlroots Surface
 
@@ -75,7 +75,7 @@ class Surface:
         lib.wlr_surface_send_frame_done(self._ptr, when._ptr)
 
 
-class SurfaceState:
+class SurfaceState(Ptr):
     def __init__(self, ptr):
         """The state of a given surface
 

--- a/wlroots/wlr_types/texture.py
+++ b/wlroots/wlr_types/texture.py
@@ -1,10 +1,10 @@
 # Copyright (c) Sean Vig 2020
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from wlroots.renderer import Renderer
 
 
-class Texture:
+class Texture(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ptr
 

--- a/wlroots/wlr_types/xcursor_manager.py
+++ b/wlroots/wlr_types/xcursor_manager.py
@@ -1,11 +1,11 @@
 # Copyright (c) Sean Vig 2019
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 
 from .cursor import Cursor
 
 
-class XCursorManager:
+class XCursorManager(Ptr):
     def __init__(self, size, scale=1):
         """Creates a new XCursor manager
 

--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, Tuple, TypeVar
 
 from pywayland.server import Display, Signal
 
-from wlroots import ffi, lib
+from wlroots import ffi, lib, Ptr
 from wlroots.util.edges import Edges
 from .box import Box
 from .output import Output
@@ -32,7 +32,7 @@ class XdgSurfaceRole(enum.IntEnum):
     POPUP = lib.WLR_XDG_SURFACE_ROLE_POPUP
 
 
-class XdgShell:
+class XdgShell(Ptr):
     def __init__(self, display: Display) -> None:
         """Create the shell for protocol windows
 
@@ -47,7 +47,7 @@ class XdgShell:
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
 
-class XdgSurface:
+class XdgSurface(Ptr):
     def __init__(self, ptr) -> None:
         """A user interface element requiring management by the compositor
 
@@ -168,7 +168,7 @@ class XdgSurface:
         )
 
 
-class XdgTopLevel:
+class XdgTopLevel(Ptr):
     def __init__(self, ptr) -> None:
         """A top level surface object
 
@@ -214,7 +214,7 @@ class XdgTopLevel:
         return ffi.string(self._ptr.app_id).decode()
 
 
-class XdgTopLevelMoveEvent:
+class XdgTopLevelMoveEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_xdg_toplevel_move_event *", ptr)
 
@@ -230,7 +230,7 @@ class XdgTopLevelMoveEvent:
         return self._ptr.serial
 
 
-class XdgTopLevelResizeEvent:
+class XdgTopLevelResizeEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_xdg_toplevel_resize_event *", ptr)
 
@@ -250,7 +250,7 @@ class XdgTopLevelResizeEvent:
         return self._ptr.edges
 
 
-class XdgTopLevelSetFullscreenEvent:
+class XdgTopLevelSetFullscreenEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_xdg_toplevel_set_fullscreen_event *", ptr)
 
@@ -268,7 +268,7 @@ class XdgTopLevelSetFullscreenEvent:
         return Output(self._ptr.output)
 
 
-class XdgTopLevelShowWindowMenuEvent:
+class XdgTopLevelShowWindowMenuEvent(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_xdg_toplevel_show_window_menu_event *", ptr)
 


### PR DESCRIPTION
This implements __eq__ in a Ptr base class that is passed to other
classes that can use it to test between their respective `self._ptr`
attributes. This means that new class instances created as part of class
properties (e.g. `Seat.keyboard` which creates a new instance of
`Keyboard`) can be compared with existing instances that represent the
same thing (i.e. have the same pointer).

--

This does appear to break the hashability of the classes, which breaks the weak referencing:
```
  File "/home/mcol/git/qtile/libqtile/backend/wayland/keyboard.py", line 55, in __init__
    self.keyboard = device.keyboard
  File "/home/mcol/git/pywlroots/wlroots/wlr_types/input_device.py", line 55, in keyboard
    _weakkeydict[keyboard] = self._ptr
  File "/usr/lib/python3.9/weakref.py", line 418, in __setitem__
    self.data[ref(key, self._remove)] = value
TypeError: unhashable type: 'Keyboard'
```

Do you think it's worth either not bothering with these changes at all (and making user code access `_ptr` when needed), changing the way it is implemented (maybe not a subclass, but a decorator or something?), or adjusting the weakreferencing so that it works?