### PR TITLE
Fix typos in XdgSurface.send_close

### DIFF
--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -126,8 +126,8 @@ class XdgSurface:
     def set_fullscreen(self, fullscreened: bool) -> int:
         return lib.wlr_xdg_toplevel_set_fullscreen(self._ptr, fullscreened)
 
-    def send_close(self, fullscreened: bool) -> int:
-        return lib.xdg_toplevel_send_close(self._ptr)
+    def send_close(self) -> int:
+        return lib.wlr_xdg_toplevel_send_close(self._ptr)
 
     def surface_at(
         self, surface_x: float, surface_y: float


### PR DESCRIPTION
Apologies, in a previous commit I copy-pasted some lines when amending the commit before submission and it got merged with the typo. the `fullscreened` arg is for the previous method, and `xdg_toplevel_send_close` is a function used internally to wlroots via `wlr_xdg_toplevel_send_close`, which is what we should use.