### PR TITLE
Add a property to Seat to determine if it has been destroyed

### DIFF
--- a/wlroots/wlr_types/seat.py
+++ b/wlroots/wlr_types/seat.py
@@ -114,6 +114,11 @@ class Seat:
             ffi.release(self._ptr)
             self._ptr = None
 
+    @property
+    def destroyed(self) -> bool:
+        """Whether this seat has been destroyed."""
+        return self._ptr is None
+
     def set_capabilities(self, capabilities: WlSeat.capability) -> None:
         """Updates the capabilities available on this seat
 


### PR DESCRIPTION
This avoids user code needing to check seat._ptr directly.