### PR TITLE
Add wlr_screencopy_v1 interface

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -544,6 +544,26 @@ struct wlr_event_pointer_pinch_end {
 };
 """
 
+# types/wlr_screencopy_v1.h
+CDEF += """
+struct wlr_screencopy_manager_v1 {
+    struct wl_global *global;
+    struct wl_list frames; // wlr_screencopy_frame_v1::link
+
+    struct wl_listener display_destroy;
+
+    struct {
+        struct wl_signal destroy;
+    } events;
+
+    void *data;
+    ...;
+};
+
+struct wlr_screencopy_manager_v1 *wlr_screencopy_manager_v1_create(
+    struct wl_display *display);
+"""
+
 # types/wlr_seat.h
 CDEF += """
 struct timespec {
@@ -1037,6 +1057,7 @@ SOURCE = """
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_shell.h>

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -15,6 +15,7 @@ from .pointer import (  # noqa: F401
     PointerEventMotion,
     PointerEventMotionAbsolute,
 )
+from .screencopy_v1 import ScreencopyManagerV1  # noqa: F401
 from .seat import Seat  # noqa: F401
 from .surface import Surface, SurfaceState  # noqa: F401
 from .texture import Texture  # noqa: F401

--- a/wlroots/wlr_types/screencopy_v1.py
+++ b/wlroots/wlr_types/screencopy_v1.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 Matt Colligan
+
+from pywayland.server import Display, Signal
+
+from wlroots import ffi, lib, Ptr
+
+
+class ScreencopyManagerV1(Ptr):
+    def __init__(self, display: "Display") -> None:
+        """Create a wlr_screencopy_manager_v1"""
+        self._ptr = lib.wlr_screencopy_manager_v1_create(display._ptr)
+
+        self.destroy_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.destroy)
+        )


### PR DESCRIPTION
This adds some wlr_screencopy_v1.h content and a class that allows for
creating of a wlr_screencopy_manager_v1 instance via
wlr_screencopy_manager_v1_create. This is sufficient for basic screen
copying functionality.