### PR TITLE
Add basic test to launch headless backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,8 @@ jobs:
         continue-on-error: ${{ matrix.wlroots-version == 'master' }}
         if: ${{ success() }}
         run: pytest -Wall
+        env:
+          WLR_HEADLESS_OUTPUTS: '1'
   flake8-test:
     name: Python ${{ matrix.python-version}} flake8 tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
         run: pytest -Wall
         env:
           WLR_HEADLESS_OUTPUTS: '1'
+          WLR_LIBINPUT_NO_DEVICES: '1'
+          WLR_RENDERER: pixman
+          WLR_RENDERER_ALLOW_SOFTWARE: '1'
   flake8-test:
     name: Python ${{ matrix.python-version}} flake8 tests
     runs-on: ubuntu-latest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import os
+
+import pytest
+
+
+@pytest.fixture
+def headless_backend():
+    old_backends = os.environ.get("WLR_BACKENDS", "")
+    os.environ["WLR_BACKENDS"] = "headless"
+    yield
+    os.environ["WLR_BACKENDS"] = old_backends

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,15 @@
+from pywayland.server import Display
+
+from wlroots.backend import Backend, BackendType
+
+
+def test_run_headless_env_var(headless_backend):
+    with Display() as display:
+        with Backend(display):
+            pass
+
+
+def test_run_headless_arg(headless_backend):
+    with Display() as display:
+        with Backend(display, backend_type=BackendType.HEADLESS):
+            pass


### PR DESCRIPTION
This is currently failing because of some issue launching the headless backend on the CI servers, but passes locally.