### PR TITLE
Add wlr_virtual_keyboard_v1 support

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -801,6 +801,39 @@ typedef void (*wlr_surface_iterator_func_t)(struct wlr_surface *surface,
 extern "Python" void surface_iterator_callback(struct wlr_surface *surface, int sx, int sy, void *data);
 """
 
+# types/wlr_virtual_keyboard_v1.h
+CDEF += """
+struct wlr_virtual_keyboard_manager_v1 {
+    struct wl_global *global;
+    struct wl_list virtual_keyboards; // struct wlr_virtual_keyboard_v1*
+
+    struct wl_listener display_destroy;
+
+    struct {
+        struct wl_signal new_virtual_keyboard; // struct wlr_virtual_keyboard_v1*
+        struct wl_signal destroy;
+    } events;
+    ...;
+};
+
+struct wlr_virtual_keyboard_v1 {
+    struct wlr_input_device input_device;
+    struct wl_resource *resource;
+    struct wlr_seat *seat;
+    bool has_keymap;
+
+    struct wl_list link;
+
+    struct {
+        struct wl_signal destroy; // struct wlr_virtual_keyboard_v1*
+    } events;
+    ...;
+};
+
+struct wlr_virtual_keyboard_manager_v1* wlr_virtual_keyboard_manager_v1_create(
+    struct wl_display *display);
+"""
+
 # types/wlr_xcursor_manager.h
 CDEF += """
 struct wlr_xcursor_manager *wlr_xcursor_manager_create(const char *name,
@@ -1038,6 +1071,7 @@ SOURCE = """
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_seat.h>
+#include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -18,5 +18,6 @@ from .pointer import (  # noqa: F401
 from .seat import Seat  # noqa: F401
 from .surface import Surface, SurfaceState  # noqa: F401
 from .texture import Texture  # noqa: F401
+from .virtual_keyboard_v1 import VirtualKeyboardManagerV1  # noqa: F401
 from .xcursor_manager import XCursorManager  # noqa: F401
 from .xdg_shell import XdgShell  # noqa: F401

--- a/wlroots/wlr_types/virtual_keyboard_v1.py
+++ b/wlroots/wlr_types/virtual_keyboard_v1.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 Matt Colligan
+
+from weakref import WeakKeyDictionary
+
+from pywayland.server import Display, Signal
+
+from .input_device import InputDevice
+from wlroots import ffi, lib, Ptr
+
+_weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
+
+
+class VirtualKeyboardManagerV1(Ptr):
+    def __init__(self, display: Display) -> None:
+        """A wlr_virtual_keyboard_manager_v1 instance."""
+        self._ptr = lib.wlr_virtual_keyboard_manager_v1_create(display._ptr)
+
+        self.new_virtual_keyboard_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.new_virtual_keyboard), data_wrapper=VirtualKeyboardV1
+        )
+        self.destroy_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.destroy)
+        )
+
+
+class VirtualKeyboardV1(Ptr):
+    def __init__(self, ptr) -> None:
+        """A wlr_virtual_keyboard_v1 instance."""
+        self._ptr = ffi.cast("struct wlr_virtual_keyboard_v1 *", ptr)
+
+        self.destroy_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.destroy), data_wrapper=VirtualKeyboardV1
+        )
+
+    @property
+    def input_device(self) -> InputDevice:
+        device_ptr = ffi.addressof(self._ptr.input_device)
+        _weakkeydict[device_ptr] = self._ptr
+        return InputDevice(device_ptr)
+
+    @property
+    def has_keymap(self) -> bool:
+        return self._ptr.has_keymap


### PR DESCRIPTION
This exposes parts of wlr_virtual_keyboard_v1.h and implements their
interface so that compositors can support virtual keyboards as inputs.

--

I'm not sure I did the weak referencing correctly. Is these the right things that need storing in the dict? I tried replicating from other files though I'm not sure I understand it fully.