### PR TITLE
Add helper to setup compositor

### DIFF
--- a/tiny/__main__.py
+++ b/tiny/__main__.py
@@ -12,10 +12,8 @@ from functools import partial
 
 from pywayland.server import Display
 
-from wlroots.backend import Backend
-from wlroots.renderer import Renderer
+from wlroots.helper import build_compositor
 from wlroots.wlr_types import (
-    Compositor,
     Cursor,
     DataDeviceManager,
     OutputLayout,
@@ -37,9 +35,7 @@ def main(argv):
     with Display() as display:
         signal.signal(signal.SIGINT, partial(sig_cb, display))
 
-        backend = Backend(display)
-        renderer = Renderer(backend, display)
-        compositor = Compositor(display, renderer)  # noqa: F841
+        compositor, backend = build_compositor(display)
         device_manager = DataDeviceManager(display)  # noqa: F841
         xdg_shell = XdgShell(display)
         with OutputLayout() as output_layout, Cursor(
@@ -50,7 +46,6 @@ def main(argv):
             tinywl_server = TinywlServer(  # noqa: F841
                 display=display,
                 backend=backend,
-                renderer=renderer,
                 xdg_shell=xdg_shell,
                 cursor=cursor,
                 cursor_manager=xcursor_manager,

--- a/tiny/server.py
+++ b/tiny/server.py
@@ -9,7 +9,6 @@ from xkbcommon import xkb
 
 from wlroots import ffi, lib
 from wlroots.backend import Backend
-from wlroots.renderer import Renderer
 from wlroots.util.edges import Edges
 from wlroots.wlr_types import (
     Box,
@@ -61,7 +60,6 @@ class TinywlServer:
         *,
         display: Display,
         backend: Backend,
-        renderer: Renderer,
         xdg_shell: XdgShell,
         cursor: Cursor,
         cursor_manager: XCursorManager,
@@ -71,7 +69,6 @@ class TinywlServer:
         # elements that we need to hold on to
         self._display = display
         self._backend = backend
-        self._renderer = renderer
 
         # the xdg shell will generate new surfaces
         self._xdg_shell = xdg_shell
@@ -297,8 +294,8 @@ class TinywlServer:
 
         output = self.outputs[0]
         width, height = output.effective_resolution()
-        with output, self._renderer.render(width, height):
-            self._renderer.clear([0.3, 0.3, 0.3, 1.0])
+        with output, self._backend.renderer.render(width, height) as renderer:
+            renderer.clear([0.3, 0.3, 0.3, 1.0])
 
             for view in self.views:
                 if not view.mapped:
@@ -333,7 +330,7 @@ class TinywlServer:
 
         matrix = Matrix.project_box(box, inverse, 0, output.transform_matrix)
 
-        self._renderer.render_texture_with_matrix(texture, matrix, 1)
+        self._backend.renderer.render_texture_with_matrix(texture, matrix, 1)
         surface.send_frame_done(now)
 
     # #############################################################

--- a/wlroots/backend.py
+++ b/wlroots/backend.py
@@ -9,6 +9,7 @@ from . import ffi, lib, Ptr
 from wlroots.util.log import logger
 from wlroots.wlr_types.input_device import InputDevice
 from wlroots.wlr_types.output import Output
+from wlroots.renderer import Renderer
 
 
 class BackendType(enum.Enum):
@@ -49,6 +50,12 @@ class Backend(Ptr):
         self.new_output_event = Signal(
             ptr=ffi.addressof(self._ptr.events.new_output), data_wrapper=Output
         )
+
+    @property
+    def renderer(self) -> Renderer:
+        """Obtains the Renderer reference this backend is using."""
+        renderer_ptr = lib.wlr_backend_get_renderer(self._ptr)
+        return Renderer(renderer_ptr)
 
     def destroy(self) -> None:
         """Destroy the backend and clean up all of its resources

--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -53,7 +53,7 @@ void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,
 const enum wl_shm_format *wlr_renderer_get_shm_texture_formats(
     struct wlr_renderer *r, size_t *len);
 
-void wlr_renderer_init_wl_display(struct wlr_renderer *r, struct wl_display *wl_display);
+bool wlr_renderer_init_wl_display(struct wlr_renderer *r, struct wl_display *wl_display);
 void wlr_renderer_destroy(struct wlr_renderer *renderer);
 """
 

--- a/wlroots/helper.py
+++ b/wlroots/helper.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 Sean Vig
+
+from typing import Tuple
+
+from pywayland.server import Display
+
+from wlroots.backend import Backend, BackendType
+from wlroots.wlr_types import Compositor
+
+
+def build_compositor(
+    display: Display, *, backend_type=BackendType.AUTO
+) -> Tuple[Compositor, Backend]:
+    """Build and run a compositor
+
+    :param display:
+        The Wayland display to attatch to the backend, renderer, and
+        compositor.
+    :param backend_type:
+        The type of the backend to setup the compositor for, by default use the
+        auto-detected backend.
+    :return:
+        The compositor and the backend.
+    """
+    backend = Backend(display, backend_type=backend_type)
+    renderer = backend.renderer
+    renderer.init_display(display)
+    compositor = Compositor(display, renderer)
+
+    return compositor, backend


### PR DESCRIPTION
The renderer can now be extracted from the backend. Change the constructor of the renderer to not need a Display, and add the display setup functionality to the compositor setup helper.