### PR TITLE
Expose wlr_xdg_decoration_v1 interface

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -1004,6 +1004,70 @@ void wlr_xcursor_manager_set_cursor_image(struct wlr_xcursor_manager *manager,
     const char *name, struct wlr_cursor *cursor);
 """
 
+# types/wlr_xdg_decoration_v1.h
+CDEF += """
+enum wlr_xdg_toplevel_decoration_v1_mode {
+    WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_NONE = 0,
+    WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE = 1,
+    WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE = 2,
+};
+
+struct wlr_xdg_decoration_manager_v1 {
+    struct wl_global *global;
+    struct wl_list decorations; // wlr_xdg_toplevel_decoration::link
+
+    struct wl_listener display_destroy;
+
+    struct {
+        struct wl_signal new_toplevel_decoration; // struct wlr_xdg_toplevel_decoration *
+        struct wl_signal destroy;
+    } events;
+
+    void *data;
+    ...;
+};
+
+struct wlr_xdg_toplevel_decoration_v1_configure {
+    struct wl_list link; // wlr_xdg_toplevel_decoration::configure_list
+    struct wlr_xdg_surface_configure *surface_configure;
+    enum wlr_xdg_toplevel_decoration_v1_mode mode;
+};
+
+struct wlr_xdg_toplevel_decoration_v1 {
+    struct wl_resource *resource;
+    struct wlr_xdg_surface *surface;
+    struct wlr_xdg_decoration_manager_v1 *manager;
+    struct wl_list link; // wlr_xdg_decoration_manager_v1::link
+
+    bool added;
+    enum wlr_xdg_toplevel_decoration_v1_mode current_mode;
+    enum wlr_xdg_toplevel_decoration_v1_mode client_pending_mode;
+    enum wlr_xdg_toplevel_decoration_v1_mode server_pending_mode;
+
+    struct wl_list configure_list; // wlr_xdg_toplevel_decoration_v1_configure::link
+
+    struct {
+        struct wl_signal destroy;
+        struct wl_signal request_mode;
+    } events;
+
+    struct wl_listener surface_destroy;
+    struct wl_listener surface_configure;
+    struct wl_listener surface_ack_configure;
+    struct wl_listener surface_commit;
+
+    void *data;
+    ...;
+};
+
+struct wlr_xdg_decoration_manager_v1 *
+    wlr_xdg_decoration_manager_v1_create(struct wl_display *display);
+
+uint32_t wlr_xdg_toplevel_decoration_v1_set_mode(
+    struct wlr_xdg_toplevel_decoration_v1 *decoration,
+    enum wlr_xdg_toplevel_decoration_v1_mode mode);
+"""
+
 # types/wlr_xdg_output_v1.h
 CDEF += """
 struct wlr_xdg_output_manager_v1 {
@@ -1277,6 +1341,7 @@ SOURCE = """
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -23,5 +23,6 @@ from .surface import Surface, SurfaceState  # noqa: F401
 from .texture import Texture  # noqa: F401
 from .virtual_keyboard_v1 import VirtualKeyboardManagerV1  # noqa: F401
 from .xcursor_manager import XCursorManager  # noqa: F401
+from .xdg_decoration_v1 import XdgDecorationManagerV1  # noqa: F401
 from .xdg_output_v1 import XdgOutputManagerV1  # noqa: F401
 from .xdg_shell import XdgShell  # noqa: F401

--- a/wlroots/wlr_types/xdg_decoration_v1.py
+++ b/wlroots/wlr_types/xdg_decoration_v1.py
@@ -1,0 +1,81 @@
+# Copyright (c) Matt Colligan 2021
+
+import enum
+from typing import TYPE_CHECKING
+from weakref import WeakKeyDictionary
+
+from pywayland.server import Signal
+
+from wlroots import ffi, lib, Ptr
+from .surface import Surface
+
+if TYPE_CHECKING:
+    from pywayland.server import Display
+
+_weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
+
+
+class XdgToplevelDecorationV1Mode(enum.IntEnum):
+    NONE = lib.WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_NONE
+    CLIENT_SIDE = lib.WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE
+    SERVER_SIDE = lib.WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE
+
+
+class XdgDecorationManagerV1(Ptr):
+    def __init__(self, ptr) -> None:
+        """An XDG decoration manager: wlr_xdg_decoration_manager_v1."""
+        self._ptr = ffi.cast("struct wlr_xdg_decoration_manager_v1 *", ptr)
+
+        self.new_toplevel_decoration_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.new_toplevel_decoration),
+            data_wrapper=XdgToplevelDecorationV1
+        )
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+
+    @classmethod
+    def create(cls, display: "Display"):
+        """Create a wlr_xdg_decoration_manager_v1 for the given display."""
+        ptr = lib.wlr_xdg_decoration_manager_v1_create(display._ptr)
+        return cls(ptr)
+
+
+class XdgToplevelDecorationV1(Ptr):
+    def __init__(self, ptr) -> None:
+        """struct wlr_xdg_toplevel_decoration_v1"""
+        self._ptr = ffi.cast("struct wlr_xdg_toplevel_decoration_v1 *", ptr)
+
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+        self.request_mode_event = Signal(ptr=ffi.addressof(self._ptr.events.request_mode))
+
+    @property
+    def surface(self) -> Surface:
+        surface_ptr = self._ptr.surface
+        _weakkeydict[surface_ptr] = self._ptr
+        return Surface(surface_ptr)
+
+    @property
+    def manager(self) -> XdgDecorationManagerV1:
+        manager_ptr = self._ptr.manager
+        _weakkeydict[manager_ptr] = self._ptr
+        return XdgDecorationManagerV1(manager_ptr)
+
+    @property
+    def added(self) -> bool:
+        return self._ptr.added
+
+    @property
+    def current_mode(self) -> XdgToplevelDecorationV1Mode:
+        return XdgToplevelDecorationV1Mode(self._ptr.current_mode)
+
+    @property
+    def client_pending_mode(self) -> XdgToplevelDecorationV1Mode:
+        return XdgToplevelDecorationV1Mode(self._ptr.client_pending_mode)
+
+    @property
+    def server_pending_mode(self) -> XdgToplevelDecorationV1Mode:
+        return XdgToplevelDecorationV1Mode(self._ptr.server_pending_mode)
+
+    def set_mode(self, mode: XdgToplevelDecorationV1Mode) -> int:
+        if mode == XdgToplevelDecorationV1Mode.NONE:
+            raise ValueError("Toplevel decoration mode cannot be set to NONE.")
+        return lib.wlr_xdg_toplevel_decoration_v1_set_mode(self._ptr, mode)


### PR DESCRIPTION
This adds wlr/types/wlr_xdg_decoration_v1.h content and handlers so that
client surfaces can request client or server side window decorations,
and the server can tell windows which to use.