### PR TITLE
Add wlr_output_damage interface

### DIFF
--- a/tiny/server.py
+++ b/tiny/server.py
@@ -294,6 +294,7 @@ class TinywlServer:
 
         output = self.outputs[0]
         width, height = output.effective_resolution()
+        output.attach_render()
         with output, self._backend.renderer.render(width, height) as renderer:
             renderer.clear([0.3, 0.3, 0.3, 1.0])
 

--- a/wlroots/renderer.py
+++ b/wlroots/renderer.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Sean Vig
 
 import contextlib
-from typing import Iterator, List, Tuple, Union
+from typing import Iterator, List, Optional, Tuple, Union
 
 from pywayland.server import Display
 
@@ -79,3 +79,11 @@ class Renderer(Ptr):
         if not isinstance(color, ffi.CData):
             color = ffi.new("float[4]", color)
         lib.wlr_render_rect(self._ptr, box._ptr, color, projection._ptr)
+
+    def scissor(self, box: Optional[Box]) -> None:
+        """
+        Defines a scissor box. Only pixels that lie within the scissor box can be
+        modified by drawing functions. Providing a NULL `box` disables the scissor
+        box.
+        """
+        lib.wlr_renderer_scissor(self._ptr, box._ptr if box else ffi.NULL)

--- a/wlroots/util/region.py
+++ b/wlroots/util/region.py
@@ -1,0 +1,53 @@
+# Copyright (c) Matt Colligan 2021
+
+from typing import List
+
+from pywayland.protocol.wayland import WlOutput
+from wlroots import ffi, lib, Ptr
+from wlroots.wlr_types.box import Box
+
+
+class PixmanRegion32(Ptr):
+    def __init__(self) -> None:
+        """This is a convenience wrapper around pixman_region32_t
+
+        :param ptr:
+            The pixman_region32_t cdata pointer
+        """
+        self._ptr = ffi.new("struct pixman_region32 *")
+
+    def __enter__(self) -> "PixmanRegion32":
+        """Use the pixman_region32 in a context manager"""
+        lib.pixman_region32_init(self._ptr)
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb) -> None:
+        """Finish up when exiting the context"""
+        lib.pixman_region32_fini(self._ptr)
+
+    def rectangles_as_boxes(self) -> List[Box]:
+        nrects_ptr = ffi.new("int *")
+        rects = lib.pixman_region32_rectangles(self._ptr, nrects_ptr)
+        nrects = nrects_ptr[0]
+
+        boxes = []
+        for i in range(nrects):
+            boxes.append(
+                Box(rects.x1, rects.y1, rects.x2 - rects.x1, rects.y2 - rects.y1)
+            )
+            rects += 1
+        return boxes
+
+    def transform(
+        self, src: "PixmanRegion32", transform: WlOutput.transform, width: int, height: int
+    ) -> None:
+        """
+        Applies a transform to a region inside a box of size `width` x `height`.
+        """
+        lib.wlr_region_transform(self._ptr, src._ptr, transform, width, height)
+
+    def not_empty(self) -> bool:
+        """
+        Wrapper around pixman_region32_not_empty
+        """
+        return lib.pixman_region32_not_empty(self._ptr)

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -10,6 +10,7 @@ from .keyboard import Keyboard  # noqa: F401
 from .layer_shell_v1 import LayerShellV1  # noqa: F401
 from .matrix import Matrix  # noqa: F401
 from .output import Output  # noqa: F401
+from .output_damage import OutputDamage  # noqa: F401
 from .output_layout import OutputLayout  # noqa: F401
 from .pointer import (  # noqa: F401
     PointerEventAxis,

--- a/wlroots/wlr_types/output_damage.py
+++ b/wlroots/wlr_types/output_damage.py
@@ -1,0 +1,71 @@
+# Copyright (c) Matt Colligan 2021
+
+from pywayland.server import Signal
+
+from wlroots import ffi, lib, Ptr
+from wlroots.util.region import PixmanRegion32
+from .box import Box
+from .output import Output
+
+
+class OutputDamage(Ptr):
+    def __init__(self, output: Output) -> None:
+        """
+        Tracks damage for an output.
+
+        The `frame` event will be emitted when it is a good time for the compositor
+        to submit a new frame.
+
+        To render a new frame, compositors should call
+        `wlr_output_damage_attach_render`, render and call `wlr_output_commit`. No
+        rendering should happen outside a `frame` event handler or before
+        `wlr_output_damage_attach_render`.
+        """
+        self._ptr = lib.wlr_output_damage_create(output._ptr)
+
+        self.frame_event = Signal(ptr=ffi.addressof(self._ptr.events.frame))
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+
+    @property
+    def output(self) -> Output:
+        """The name of the output"""
+        return Output(self._ptr.output)
+
+    def destroy(self) -> None:
+        """The name of the output"""
+        lib.wlr_output_damage_destroy(self._ptr)
+        self._ptr = None
+
+    def attach_render(self, damage: PixmanRegion32) -> bool:
+        """
+        Attach the renderer's buffer to the output. Compositors must call this
+        function before rendering. After they are done rendering, they should call
+        `wlr_output_set_damage` and `wlr_output_commit` to submit the new frame.
+
+        `needs_frame` will be set to true if a frame should be submitted. `damage`
+        will be set to the region of the output that needs to be repainted, in
+        output-buffer-local coordinates.
+
+        The buffer damage region accumulates all damage since the buffer has last
+        been swapped. This is not to be confused with the output surface damage,
+        which only contains the changes between two frames.
+
+        Returns a bool specifying whether the output needs a new frame rendered.
+        """
+        needs_frame_ptr = ffi.new("bool *")
+        if not lib.wlr_output_damage_attach_render(self._ptr, needs_frame_ptr, damage._ptr):
+            raise RuntimeError("Rendering on output failed")
+
+        return needs_frame_ptr[0]
+
+    def add(self, damage: PixmanRegion32) -> None:
+        """Accumulates damage and schedules a `frame` event."""
+        lib.wlr_output_damage_add(self._ptr, damage._ptr)
+
+    def add_whole(self) -> None:
+        """Damages the whole output and schedules a `frame` event."""
+        lib.wlr_output_damage_add_whole(self._ptr)
+
+    def add_box(self, box: Box) -> None:
+        """Accumulates damage from a box and schedules a `frame` event."""
+        lib.wlr_output_damage_add_box(self._ptr, box._ptr)


### PR DESCRIPTION
This adds an interface for `struct wlr_output_damage`, a corresponding
class OutputDamage, whose methods map onto the various functions that
operate on this struct.

This also adds a class wrapper around `pixman_region32_t` (already
included in the ffi_build C definition) for use by some of these
methods.