### PR TITLE
Implement wlr output management v1

### DIFF
--- a/wlroots/__init__.py
+++ b/wlroots/__init__.py
@@ -1,5 +1,7 @@
 # Copyright (c) Sean Vig 2018
 
+from typing import Any
+
 from ._ffi import ffi, lib  # noqa: F401
 
 __wlroots_version__ = "{}.{}.{}".format(
@@ -28,3 +30,19 @@ class Ptr:
     def __hash__(self) -> int:
         """Use the hash from `object`, which is unique per object"""
         return super().__hash__()
+
+
+class PtrHasData(Ptr):
+    """
+    Add methods to get and set the void *data member on the wrapped struct. The value
+    stored can be of any Python type.
+    """
+
+    @property
+    def data(self) -> Any:
+        return ffi.from_handle(self._ptr.data)
+
+    @data.setter
+    def data(self, data: Any) -> None:
+        self._data_handle = ffi.new_handle(data)
+        self._ptr.data = self._data_handle

--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -1196,6 +1196,39 @@ struct wlr_xdg_shell {
     ...;
 };
 
+struct wlr_xdg_positioner {
+    struct wlr_box anchor_rect;
+    enum xdg_positioner_anchor anchor;
+    enum xdg_positioner_gravity gravity;
+    enum xdg_positioner_constraint_adjustment constraint_adjustment;
+
+    struct {
+        int32_t width, height;
+    } size;
+
+    struct {
+        int32_t x, y;
+    } offset;
+    ...;
+};
+
+struct wlr_xdg_popup {
+    struct wlr_xdg_surface *base;
+    struct wl_list link;
+
+    struct wl_resource *resource;
+    bool committed;
+    struct wlr_surface *parent;
+    struct wlr_seat *seat;
+
+    struct wlr_box geometry;
+
+    struct wlr_xdg_positioner positioner;
+
+    struct wl_list grab_link; // wlr_xdg_popup_grab::popups
+    ...;
+};
+
 struct wlr_xdg_shell *wlr_xdg_shell_create(struct wl_display *display);
 
 struct wlr_xdg_toplevel_state {
@@ -1317,6 +1350,9 @@ struct wlr_xdg_toplevel_show_window_menu_event {
     uint32_t x, y;
     ...;
 };
+
+void wlr_xdg_popup_unconstrain_from_box(struct wlr_xdg_popup *popup,
+    const struct wlr_box *toplevel_sx_box);
 
 void wlr_xdg_surface_ping(struct wlr_xdg_surface *surface);
 

--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -538,6 +538,22 @@ void wlr_output_layout_destroy(struct wlr_output_layout *layout);
 void wlr_output_layout_output_coords(struct wlr_output_layout *layout,
     struct wlr_output *reference, double *lx, double *ly);
 
+void wlr_output_layout_closest_point(struct wlr_output_layout *layout,
+    struct wlr_output *reference, double lx, double ly, double *dest_lx,
+    double *dest_ly);
+
+void wlr_output_layout_add(struct wlr_output_layout *layout,
+    struct wlr_output *output, int lx, int ly);
+
+void wlr_output_layout_move(struct wlr_output_layout *layout,
+    struct wlr_output *output, int lx, int ly);
+
+void wlr_output_layout_remove(struct wlr_output_layout *layout,
+    struct wlr_output *output);
+
+struct wlr_box *wlr_output_layout_get_box(
+    struct wlr_output_layout *layout, struct wlr_output *reference);
+
 void wlr_output_layout_add_auto(struct wlr_output_layout *layout,
     struct wlr_output *output);
 

--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -1289,6 +1289,18 @@ struct wlr_xdg_shell {
     ...;
 };
 
+struct wlr_xdg_client {
+    struct wlr_xdg_shell *shell;
+    struct wl_resource *resource;
+    struct wl_client *client;
+    struct wl_list surfaces;
+
+    struct wl_list link; // wlr_xdg_shell::clients
+
+    uint32_t ping_serial;
+    struct wl_event_source *ping_timer;
+};
+
 struct wlr_xdg_positioner {
     struct wlr_box anchor_rect;
     enum xdg_positioner_anchor anchor;

--- a/wlroots/util/region.py
+++ b/wlroots/util/region.py
@@ -42,7 +42,11 @@ class PixmanRegion32(Ptr):
         return boxes
 
     def transform(
-        self, src: "PixmanRegion32", transform: WlOutput.transform, width: int, height: int
+        self,
+        src: "PixmanRegion32",
+        transform: WlOutput.transform,
+        width: int,
+        height: int,
     ) -> None:
         """
         Applies a transform to a region inside a box of size `width` x `height`.

--- a/wlroots/util/region.py
+++ b/wlroots/util/region.py
@@ -8,13 +8,16 @@ from wlroots.wlr_types.box import Box
 
 
 class PixmanRegion32(Ptr):
-    def __init__(self) -> None:
+    def __init__(self, ptr=None) -> None:
         """This is a convenience wrapper around pixman_region32_t
 
         :param ptr:
             The pixman_region32_t cdata pointer
         """
-        self._ptr = ffi.new("struct pixman_region32 *")
+        if ptr is None:
+            self._ptr = ffi.new("struct pixman_region32 *")
+        else:
+            self._ptr = ptr
 
     def __enter__(self) -> "PixmanRegion32":
         """Use the pixman_region32 in a context manager"""

--- a/wlroots/wlr_types/box.py
+++ b/wlroots/wlr_types/box.py
@@ -1,4 +1,7 @@
 # Copyright Sean Vig (c) 2020
+# Copyright Matt Colligan (c) 2021
+
+from typing import Optional
 
 from wlroots import ffi
 
@@ -18,13 +21,28 @@ def _int_setter(attr):
 
 
 class Box:
-    def __init__(self, x: int, y: int, width: int, height: int) -> None:
+    def __init__(
+        self,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        ptr=None,
+    ) -> None:
         """A simple box structure, represented by a coordinate and dimensions"""
-        self._ptr = ffi.new("struct wlr_box *")
-        self.x = x
-        self.y = y
-        self.width = width
-        self.height = height
+        if ptr is None:
+            self._ptr = ffi.new("struct wlr_box *")
+        else:
+            self._ptr = ptr
+
+        if x is not None:
+            self.x = x
+        if y is not None:
+            self.y = y
+        if width is not None:
+            self.width = width
+        if height is not None:
+            self.height = height
 
     x = property(_int_getter("x"), _int_setter("x"))
     y = property(_int_getter("y"), _int_setter("y"))

--- a/wlroots/wlr_types/cursor.py
+++ b/wlroots/wlr_types/cursor.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 
 from pywayland.server import Signal
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib
 from .input_device import InputDevice, InputDeviceType
 from .output_layout import OutputLayout
 from .pointer import (
@@ -29,7 +29,7 @@ class WarpMode(enum.Enum):
     AbsoluteClosest = enum.auto()
 
 
-class Cursor(Ptr):
+class Cursor(PtrHasData):
     def __init__(self, output_layout: OutputLayout) -> None:
         """Manage a cursor attached to the given output layout
 

--- a/wlroots/wlr_types/gamma_control_v1.py
+++ b/wlroots/wlr_types/gamma_control_v1.py
@@ -2,10 +2,10 @@
 
 from pywayland.server import Display, Signal
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib
 
 
-class GammaControlManagerV1(Ptr):
+class GammaControlManagerV1(PtrHasData):
     def __init__(self, display: Display) -> None:
         """Creates a wlr_gamma_control_manager_v1"""
         self._ptr = lib.wlr_gamma_control_manager_v1_create(display._ptr)

--- a/wlroots/wlr_types/input_device.py
+++ b/wlroots/wlr_types/input_device.py
@@ -4,7 +4,7 @@ import enum
 import weakref
 
 from .keyboard import Keyboard
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib
 
 _weakkeydict: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
@@ -25,7 +25,7 @@ class InputDeviceType(enum.IntEnum):
     SWITCH = lib.WLR_INPUT_DEVICE_SWITCH
 
 
-class InputDevice(Ptr):
+class InputDevice(PtrHasData):
     def __init__(self, ptr) -> None:
         """Create the input device from the given cdata
 

--- a/wlroots/wlr_types/keyboard.py
+++ b/wlroots/wlr_types/keyboard.py
@@ -6,7 +6,7 @@ from weakref import WeakKeyDictionary
 from pywayland.server import Signal
 from pywayland.protocol.wayland import WlKeyboard
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib, Ptr
 
 _weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
 
@@ -60,7 +60,7 @@ class KeyboardKeyEvent(Ptr):
         return WlKeyboard.key_state(self._ptr.state)
 
 
-class Keyboard(Ptr):
+class Keyboard(PtrHasData):
     def __init__(self, ptr) -> None:
         """The Keyboard wlroots object
 

--- a/wlroots/wlr_types/layer_shell_v1.py
+++ b/wlroots/wlr_types/layer_shell_v1.py
@@ -7,7 +7,7 @@ from weakref import WeakKeyDictionary
 
 from pywayland.server import Signal
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib, Ptr
 from .output import Output
 from .surface import Surface
 from .xdg_shell import SurfaceCallback, T
@@ -90,7 +90,7 @@ class LayerSurfaceV1State(Ptr):
         return LayerShellV1Layer(self._ptr.layer)
 
 
-class LayerSurfaceV1(Ptr):
+class LayerSurfaceV1(PtrHasData):
     def __init__(self, ptr):
         self._ptr = ffi.cast("struct wlr_layer_surface_v1 *", ptr)
 
@@ -199,7 +199,7 @@ class LayerSurfaceV1(Ptr):
         return Surface(surface_ptr), sub_x_data[0], sub_y_data[0]
 
 
-class LayerShellV1(Ptr):
+class LayerShellV1(PtrHasData):
     def __init__(self, display: "Display") -> None:
         """Create an wlr_xdg_output_manager_v1"""
         self._ptr = lib.wlr_layer_shell_v1_create(display._ptr)

--- a/wlroots/wlr_types/output.py
+++ b/wlroots/wlr_types/output.py
@@ -82,6 +82,10 @@ class Output(PtrHasData):
         return self._ptr.enabled
 
     @property
+    def current_mode(self) -> "OutputMode":
+        return OutputMode(self._ptr.current_mode)
+
+    @property
     def scale(self) -> float:
         return self._ptr.scale
 
@@ -118,6 +122,16 @@ class Output(PtrHasData):
         The output needs to be enabled.
         """
         lib.wlr_output_set_mode(self._ptr, mode._ptr)
+
+    def set_custom_mode(
+        self, mode: "OutputMode", width: int, height: int, refresh: int
+    ) -> None:
+        """
+        Sets a custom mode on the output. If modes are available, they are preferred.
+        Setting `refresh` to zero lets the backend pick a preferred value. The
+        output needs to be enabled.
+        """
+        lib.wlr_output_set_custom_mode(self._ptr, width, height, refresh)
 
     def create_global(self) -> None:
         """Create the global corresponding to the output"""
@@ -205,6 +219,32 @@ class Output(PtrHasData):
         than what changed since last frame since multiple render buffers are used.
         """
         lib.wlr_output_set_damage(self._ptr, damage._ptr)
+
+    def set_transform(self, transform: WlOutput.transform) -> None:
+        """
+        Sets a transform for the output.
+
+        Transform is double-buffered state, see `wlr_output_commit`.
+        """
+        lib.wlr_output_set_transform(self._ptr, transform)
+
+    def set_scale(self, scale: float) -> None:
+        """
+        Sets a scale for the output.
+
+        Scale is double-buffered state, see `wlr_output_commit`.
+        """
+        lib.wlr_output_set_scale(self._ptr, scale)
+
+    def test(self) -> bool:
+        """
+        Test whether the pending output state would be accepted by the backend. If
+        this function returns true, `wlr_output_commit` can only fail due to a
+        runtime error.
+
+        This function doesn't mutate the pending state.
+        """
+        return lib.wlr_output_test(self._ptr)
 
 
 class OutputMode(Ptr):

--- a/wlroots/wlr_types/output.py
+++ b/wlroots/wlr_types/output.py
@@ -6,12 +6,12 @@ from typing import Tuple, Optional
 from pywayland.server import Signal
 from pywayland.protocol.wayland import WlOutput
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib, Ptr
 from wlroots.util.region import PixmanRegion32
 from .matrix import Matrix
 
 
-class Output(Ptr):
+class Output(PtrHasData):
     def __init__(self, ptr) -> None:
         """A compositor output region
 

--- a/wlroots/wlr_types/output_damage.py
+++ b/wlroots/wlr_types/output_damage.py
@@ -53,7 +53,9 @@ class OutputDamage(Ptr):
         Returns a bool specifying whether the output needs a new frame rendered.
         """
         needs_frame_ptr = ffi.new("bool *")
-        if not lib.wlr_output_damage_attach_render(self._ptr, needs_frame_ptr, damage._ptr):
+        if not lib.wlr_output_damage_attach_render(
+            self._ptr, needs_frame_ptr, damage._ptr
+        ):
             raise RuntimeError("Rendering on output failed")
 
         return needs_frame_ptr[0]

--- a/wlroots/wlr_types/output_damage.py
+++ b/wlroots/wlr_types/output_damage.py
@@ -31,6 +31,10 @@ class OutputDamage(Ptr):
         """The name of the output"""
         return Output(self._ptr.output)
 
+    @property
+    def current(self) -> PixmanRegion32:
+        return PixmanRegion32(ffi.addressof(self._ptr.current))
+
     def destroy(self) -> None:
         """The name of the output"""
         lib.wlr_output_damage_destroy(self._ptr)

--- a/wlroots/wlr_types/output_layout.py
+++ b/wlroots/wlr_types/output_layout.py
@@ -2,6 +2,8 @@
 
 from typing import Optional, Tuple
 
+from pywayland.server import Signal
+
 from wlroots import ffi, lib, Ptr
 from .box import Box
 from .output import Output
@@ -17,6 +19,10 @@ class OutputLayout(Ptr):
         """
         ptr = lib.wlr_output_layout_create()
         self._ptr = ffi.gc(ptr, lib.wlr_output_layout_destroy)
+
+        self.add_event = Signal(ptr=ffi.addressof(ptr.events.add))
+        self.change_event = Signal(ptr=ffi.addressof(ptr.events.change))
+        self.destroy_event = Signal(ptr=ffi.addressof(ptr.events.destroy))
 
     def destroy(self) -> None:
         """Destroy the current output layout"""
@@ -38,7 +44,7 @@ class OutputLayout(Ptr):
         """
         lib.wlr_output_layout_add_auto(self._ptr, output._ptr)
 
-    def output_coords(self, output) -> Tuple[float, float]:
+    def output_coords(self, output: Output) -> Tuple[float, float]:
         """Determine coordinates of the output in the layout
 
         Given x and y in layout coordinates, adjusts them to local output

--- a/wlroots/wlr_types/output_management_v1.py
+++ b/wlroots/wlr_types/output_management_v1.py
@@ -1,0 +1,180 @@
+# Copyright (c) Matt Colligan 2021
+
+from dataclasses import dataclass
+from typing import Iterator
+
+from pywayland.server import Display, Signal
+from pywayland.protocol.wayland import WlOutput
+from pywayland.utils import wl_list_for_each
+
+from wlroots import ffi, lib, Ptr
+from .output import Output, OutputMode
+
+
+@dataclass
+class CustomMode:
+    """The custom_mode struct member of wlr_output_state"""
+
+    width: int
+    height: int
+    refresh: int
+
+
+class OutputHeadV1State(Ptr):
+    def __init__(self, ptr) -> None:
+        """wlr_output_head_v1_state"""
+        self._ptr = ptr
+
+    @property
+    def enabled(self) -> bool:
+        return self._ptr.enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self._ptr.enabled = value
+
+    @property
+    def x(self) -> int:
+        return self._ptr.x
+
+    @x.setter
+    def x(self, value: int) -> None:
+        self._ptr.x = value
+
+    @property
+    def y(self) -> int:
+        return self._ptr.y
+
+    @y.setter
+    def y(self, value: int) -> None:
+        self._ptr.y = value
+
+    @property
+    def scale(self) -> float:
+        return self._ptr.scale
+
+    @scale.setter
+    def scale(self, value: float) -> None:
+        self._ptr.scale = value
+
+    @property
+    def output(self) -> Output:
+        return Output(self._ptr.output)
+
+    @property
+    def mode(self) -> OutputMode:
+        return OutputMode(self._ptr.mode)
+
+    @mode.setter
+    def mode(self, value: OutputMode) -> None:
+        self._ptr.mode = value._ptr
+
+    @property
+    def custom_mode(self):
+        width = self._ptr.custom_mode.width
+        height = self._ptr.custom_mode.height
+        refresh = self._ptr.custom_mode.refresh
+        return CustomMode(width, height, refresh)
+
+    @custom_mode.setter
+    def custom_mode(self):
+        width = self._ptr.custom_mode.width
+        height = self._ptr.custom_mode.height
+        refresh = self._ptr.custom_mode.refresh
+        return CustomMode(width, height, refresh)
+
+    @property
+    def transform(self) -> WlOutput.transform:
+        return WlOutput.transform(self._ptr.transform)
+
+    @transform.setter
+    def transform(self, value: WlOutput.transform) -> None:
+        self._ptr.transform = value
+
+
+class OutputConfigurationV1(Ptr):
+    def __init__(self, ptr=None) -> None:
+        """wlr_output_configuration_v1
+
+        If a pointer is not given, a new instance is created. Pointers are given when
+        these are returned by OutputManagerV1's events.
+        """
+        if ptr is None:
+            self._ptr = lib.wlr_output_configuration_v1_create()
+        else:
+            self._ptr = ffi.cast("struct wlr_output_configuration_v1 *", ptr)
+
+    @property
+    def heads(self) -> Iterator["OutputConfigurationHeadV1"]:
+        for ptr in wl_list_for_each(
+            "struct wlr_output_configuration_head_v1 *",
+            self._ptr.heads,
+            "link",
+            ffi=ffi,
+        ):
+            yield OutputConfigurationHeadV1(ptr)
+
+    def send_succeeded(self) -> None:
+        """
+        If the configuration comes from a client request, this sends positive
+        feedback to the client (configuration has been applied).
+        """
+        lib.wlr_output_configuration_v1_send_succeeded(self._ptr)
+
+    def send_failed(self) -> None:
+        """
+        If the configuration comes from a client request, this sends negative
+        feedback to the client (configuration has not been applied).
+        """
+        lib.wlr_output_configuration_v1_send_failed(self._ptr)
+
+    def destroy(self) -> None:
+        """Destroy the instance."""
+        lib.wlr_output_configuration_v1_destroy(self._ptr)
+
+
+class OutputConfigurationHeadV1(Ptr):
+    def __init__(self, ptr) -> None:
+        """An instance of wlr_output_configuration_head_v1"""
+        self._ptr = ptr
+
+    @classmethod
+    def create(
+        cls, config: OutputConfigurationV1, output: Output
+    ) -> "OutputConfigurationHeadV1":
+        """Create a new wlr_output_configuration_head_v1"""
+        ptr = lib.wlr_output_configuration_head_v1_create(config._ptr, output._ptr)
+        return OutputConfigurationHeadV1(ptr)
+
+    @property
+    def state(self) -> OutputHeadV1State:
+        return OutputHeadV1State(self._ptr.state)
+
+
+class OutputManagerV1(Ptr):
+    def __init__(self, display: Display) -> None:
+        """Create a wlr_output_manager_v1
+
+        Create a new output manager. The compositor is responsible for calling
+        `wlr_output_manager_v1_set_configuration` whenever the current output
+        configuration changes.
+        """
+        self._ptr = lib.wlr_output_manager_v1_create(display._ptr)
+
+        self.apply_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.apply),
+            data_wrapper=OutputConfigurationV1,
+        )
+        self.test_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.test), data_wrapper=OutputConfigurationV1
+        )
+
+    def set_configuration(self, config: OutputConfigurationV1) -> None:
+        """
+        Updates the output manager's current configuration. This will broadcast any
+        changes to all clients.
+
+        This function takes ownership over `config`. That is, the compositor must not
+        access the configuration anymore.
+        """
+        lib.wlr_output_manager_v1_set_configuration(self._ptr, config._ptr)

--- a/wlroots/wlr_types/screencopy_v1.py
+++ b/wlroots/wlr_types/screencopy_v1.py
@@ -2,10 +2,10 @@
 
 from pywayland.server import Display, Signal
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib
 
 
-class ScreencopyManagerV1(Ptr):
+class ScreencopyManagerV1(PtrHasData):
     def __init__(self, display: "Display") -> None:
         """Create a wlr_screencopy_manager_v1"""
         self._ptr = lib.wlr_screencopy_manager_v1_create(display._ptr)

--- a/wlroots/wlr_types/seat.py
+++ b/wlroots/wlr_types/seat.py
@@ -6,7 +6,7 @@ from weakref import WeakKeyDictionary
 from pywayland.server import Display, Signal
 from pywayland.protocol.wayland import WlSeat
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib, Ptr
 from .input_device import ButtonState, InputDevice
 from .keyboard import Keyboard, KeyboardModifiers, KeyboardKeyEvent
 from .pointer import AxisSource, AxisOrientation
@@ -31,7 +31,7 @@ class KeyboardGrab(Ptr):
         lib.wlr_seat_keyboard_end_grab(self._seat)
 
 
-class Seat(Ptr):
+class Seat(PtrHasData):
     def __init__(self, display: Display, name: str) -> None:
         """Allocates a new seat and adds a seat global to the display
 

--- a/wlroots/wlr_types/surface.py
+++ b/wlroots/wlr_types/surface.py
@@ -5,14 +5,14 @@ from weakref import WeakKeyDictionary
 from pywayland.protocol.wayland import WlOutput
 from pywayland.server import Signal
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib, Ptr
 from wlroots.util.clock import Timespec
 from .texture import Texture
 
 _weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
 
 
-class Surface(Ptr):
+class Surface(PtrHasData):
     def __init__(self, ptr):
         """Create a wlroots Surface
 

--- a/wlroots/wlr_types/xdg_decoration_v1.py
+++ b/wlroots/wlr_types/xdg_decoration_v1.py
@@ -28,7 +28,7 @@ class XdgDecorationManagerV1(PtrHasData):
 
         self.new_toplevel_decoration_event = Signal(
             ptr=ffi.addressof(self._ptr.events.new_toplevel_decoration),
-            data_wrapper=XdgToplevelDecorationV1
+            data_wrapper=XdgToplevelDecorationV1,
         )
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
@@ -45,7 +45,9 @@ class XdgToplevelDecorationV1(PtrHasData):
         self._ptr = ffi.cast("struct wlr_xdg_toplevel_decoration_v1 *", ptr)
 
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
-        self.request_mode_event = Signal(ptr=ffi.addressof(self._ptr.events.request_mode))
+        self.request_mode_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_mode)
+        )
 
     @property
     def surface(self) -> Surface:

--- a/wlroots/wlr_types/xdg_decoration_v1.py
+++ b/wlroots/wlr_types/xdg_decoration_v1.py
@@ -6,7 +6,7 @@ from weakref import WeakKeyDictionary
 
 from pywayland.server import Signal
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib
 from .surface import Surface
 
 if TYPE_CHECKING:
@@ -21,7 +21,7 @@ class XdgToplevelDecorationV1Mode(enum.IntEnum):
     SERVER_SIDE = lib.WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE
 
 
-class XdgDecorationManagerV1(Ptr):
+class XdgDecorationManagerV1(PtrHasData):
     def __init__(self, ptr) -> None:
         """An XDG decoration manager: wlr_xdg_decoration_manager_v1."""
         self._ptr = ffi.cast("struct wlr_xdg_decoration_manager_v1 *", ptr)
@@ -39,7 +39,7 @@ class XdgDecorationManagerV1(Ptr):
         return cls(ptr)
 
 
-class XdgToplevelDecorationV1(Ptr):
+class XdgToplevelDecorationV1(PtrHasData):
     def __init__(self, ptr) -> None:
         """struct wlr_xdg_toplevel_decoration_v1"""
         self._ptr = ffi.cast("struct wlr_xdg_toplevel_decoration_v1 *", ptr)

--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -65,6 +65,9 @@ class XdgSurface(PtrHasData):
         self.map_event = Signal(ptr=ffi.addressof(self._ptr.events.map))
         self.unmap_event = Signal(ptr=ffi.addressof(self._ptr.events.unmap))
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+        self.new_popup_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.new_popup), data_wrapper=XdgPopup
+        )
 
     @classmethod
     def from_surface(cls, surface: Surface) -> "XdgSurface":
@@ -292,3 +295,26 @@ class XdgTopLevelShowWindowMenuEvent(Ptr):
     @property
     def y(self) -> int:
         return self._ptr.y
+
+
+class XdgPopup(Ptr):
+    def __init__(self, ptr) -> None:
+        """A wlr_xdg_popup
+
+        :param ptr:
+            The wlr_xdg_popup cdata pointer
+        """
+        self._ptr = ffi.cast("struct wlr_xdg_popup *", ptr)
+
+    @property
+    def base(self) -> XdgSurface:
+        """The xdg surface associated with the popup"""
+        return XdgSurface(self._ptr.base)
+
+    def unconstrain_from_box(self, box: Box) -> None:
+        """
+        Set the geometry of this popup to unconstrain it according to its xdg-positioner
+        rules. The box should be in the popup's root toplevel parent surface coordinate
+        system.
+        """
+        lib.wlr_xdg_popup_unconstrain_from_box(self._ptr, box._ptr)

--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, Tuple, TypeVar
 
 from pywayland.server import Display, Signal
 
-from wlroots import ffi, lib, Ptr
+from wlroots import ffi, PtrHasData, lib, Ptr
 from wlroots.util.edges import Edges
 from .box import Box
 from .output import Output
@@ -32,7 +32,7 @@ class XdgSurfaceRole(enum.IntEnum):
     POPUP = lib.WLR_XDG_SURFACE_ROLE_POPUP
 
 
-class XdgShell(Ptr):
+class XdgShell(PtrHasData):
     def __init__(self, display: Display) -> None:
         """Create the shell for protocol windows
 
@@ -47,7 +47,7 @@ class XdgShell(Ptr):
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
 
-class XdgSurface(Ptr):
+class XdgSurface(PtrHasData):
     def __init__(self, ptr) -> None:
         """A user interface element requiring management by the compositor
 


### PR DESCRIPTION
This first lets PixmanRegion32 and Box be instantiated using pointers to objects that already exist, rather than creating new instances of these structs when instantiating the class.

The the third commit adds handlers for the various structs and methods in wlroots'
wlr_output_management_v1.h. This lets compositors create output managers
and process client requests to change the output layout and
configuration of each output. The output layout and output interfaces
have been extended somewhat to allow for the interaction between these
and the output manager objects.