### PR TITLE
Output.set_custom_mode should not have a `mode` argument

### DIFF
--- a/wlroots/wlr_types/output.py
+++ b/wlroots/wlr_types/output.py
@@ -123,9 +123,7 @@ class Output(PtrHasData):
         """
         lib.wlr_output_set_mode(self._ptr, mode._ptr)
 
-    def set_custom_mode(
-        self, mode: "OutputMode", width: int, height: int, refresh: int
-    ) -> None:
+    def set_custom_mode(self, width: int, height: int, refresh: int) -> None:
         """
         Sets a custom mode on the output. If modes are available, they are preferred.
         Setting `refresh` to zero lets the backend pick a preferred value. The


### PR DESCRIPTION
This was a typo left in from copy-pasting the `set_mode` method.
`set_custom_mode` should only take width, height and refresh.

--

Should this not have been picked up by the CI as an unused argument?