### PR TITLE
Add wlr_texture_write_pixels to lib

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -69,6 +69,8 @@ bool wlr_texture_write_pixels(struct wlr_texture *texture,
     uint32_t stride, uint32_t width, uint32_t height,
     uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
     const void *data);
+
+void wlr_texture_destroy(struct wlr_texture *texture);
 """
 
 # types/wlr_box.h

--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -64,6 +64,11 @@ CDEF += """
 struct wlr_texture *wlr_texture_from_pixels(struct wlr_renderer *renderer,
     uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
     const void *data);
+
+bool wlr_texture_write_pixels(struct wlr_texture *texture,
+    uint32_t stride, uint32_t width, uint32_t height,
+    uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
+    const void *data);
 """
 
 # types/wlr_box.h

--- a/wlroots/wlr_types/texture.py
+++ b/wlroots/wlr_types/texture.py
@@ -59,3 +59,8 @@ class Texture(Ptr):
         return lib.wlr_texture_write_pixels(
             self._ptr, stride, width, height, src_x, src_y, dst_x, dst_y, data,
         )
+
+    def destroy(self) -> None:
+        """Destroys this wlr_texture."""
+        if self._ptr is not None:
+            lib.wlr_texture_destroy(self._ptr)

--- a/wlroots/wlr_types/texture.py
+++ b/wlroots/wlr_types/texture.py
@@ -1,4 +1,5 @@
 # Copyright (c) Sean Vig 2020
+# Copyright (c) Matt Colligan 2021
 
 
 import typing
@@ -34,3 +35,27 @@ class Texture(Ptr):
             renderer._ptr, fmt, stride, width, height, data
         )
         return Texture(ptr)
+
+    def write_pixels(
+        self,
+        stride: int,
+        width: int,
+        height: int,
+        data: ffi.CData,
+        src_x: int = 0,
+        src_y: int = 0,
+        dst_x: int = 0,
+        dst_y: int = 0,
+    ) -> bool:
+        """
+        Update a texture with raw pixels. The texture must be mutable, and the input
+        data must have the same pixel format that the texture was created with.
+
+        Should not be called in a rendering block like renderer_begin()/end() or
+        between attaching a renderer to an output and committing it.
+
+        data must be a CData pointer to pixel data.
+        """
+        return lib.wlr_texture_write_pixels(
+            self._ptr, stride, width, height, src_x, src_y, dst_x, dst_y, data,
+        )


### PR DESCRIPTION
This adds the above function to ffi_build.py and a corresponding method
to `Texture`. This lets you modify pixels in a mutable `Texture`.