### PR TITLE
Implement wlr_server_decoration with bare manager

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -985,6 +985,31 @@ void wlr_seat_keyboard_clear_focus(struct wlr_seat *wlr_seat);
 bool wlr_seat_keyboard_has_grab(struct wlr_seat *seat);
 """
 
+# types/wlr_server_decoration.h
+CDEF += """
+enum wlr_server_decoration_manager_mode {
+    WLR_SERVER_DECORATION_MANAGER_MODE_NONE = 0,
+    WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT = 1,
+    WLR_SERVER_DECORATION_MANAGER_MODE_SERVER = 2,
+};
+struct wlr_server_decoration_manager {
+    struct wl_global *global;
+    struct wl_list resources; // wl_resource_get_link
+    struct wl_list decorations; // wlr_server_decoration::link
+    uint32_t default_mode; // enum wlr_server_decoration_manager_mode
+    struct wl_listener display_destroy;
+    struct {
+        struct wl_signal new_decoration;
+        struct wl_signal destroy;
+    } events;
+    void *data;
+};
+struct wlr_server_decoration_manager *wlr_server_decoration_manager_create(
+    struct wl_display *display);
+void wlr_server_decoration_manager_set_default_mode(
+    struct wlr_server_decoration_manager *manager, uint32_t default_mode);
+"""
+
 # types/wlr_surface.h
 CDEF += """
 struct wlr_surface_state {
@@ -1574,6 +1599,7 @@ SOURCE = """
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_seat.h>
+#include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>

--- a/wlroots/wlr_types/server_decoration.py
+++ b/wlroots/wlr_types/server_decoration.py
@@ -1,0 +1,37 @@
+# Copyright (c) Matt Colligan 2021
+#
+# This protocol is obsolete and will be removed in a future version. The recommended
+# replacement is xdg-decoration.
+
+import enum
+from typing import TYPE_CHECKING
+
+from wlroots import PtrHasData, lib
+
+if TYPE_CHECKING:
+    from pywayland.server import Display
+
+
+class ServerDecorationManagerMode(enum.IntEnum):
+    NONE = lib.WLR_SERVER_DECORATION_MANAGER_MODE_NONE
+    CLIENT = lib.WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT
+    SERVER = lib.WLR_SERVER_DECORATION_MANAGER_MODE_SERVER
+
+
+class ServerDecorationManager(PtrHasData):
+    def __init__(self, ptr) -> None:
+        """
+        A decoration negotiation interface which implements the KDE protocol:
+        wlr_server_decoration_manager.
+        """
+        self._ptr = ptr
+
+    @classmethod
+    def create(cls, display: "Display") -> "ServerDecorationManager":
+        """Create a wlr_server_decoration_manager for the given display."""
+        ptr = lib.wlr_server_decoration_manager_create(display._ptr)
+        return cls(ptr)
+
+    def set_default_mode(self, default_mode: ServerDecorationManagerMode) -> None:
+        """Set the default decoration mode for this server"""
+        lib.wlr_server_decoration_manager_set_default_mode(self._ptr, default_mode)


### PR DESCRIPTION
This adds an interface to wlr/types/wlr_server_decoration.h. Only the
core part, the server decoration manager, is added, as this is sufficent
for most compositor use-cases to allow for clients using this protocol
to detect whether they should be using server or client-side
decorations. This wlroots interface is becoming deprecated in a future
version of wlroots (not necessarily the next version). However, this
will not happen until GTK, which uses this protocol, updates to the
alternative xdg_decoration. Until these updates have been done, this
protocol is useful to keep window decorations consistent.