### PR TITLE
Remove wl_shm_format

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -52,7 +52,7 @@ bool wlr_render_texture_with_matrix(struct wlr_renderer *r,
 void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,
     const float color[static 4], const float projection[static 9]);
 
-const enum wl_shm_format *wlr_renderer_get_shm_texture_formats(
+const uint32_t *wlr_renderer_get_shm_texture_formats(
     struct wlr_renderer *r, size_t *len);
 
 bool wlr_renderer_init_wl_display(struct wlr_renderer *r, struct wl_display *wl_display);


### PR DESCRIPTION
The use of this enum was replaced with a uint32_t upstream for 0.13.0