### PR TITLE
Add str_or_none helper function

### DIFF
--- a/wlroots/__init__.py
+++ b/wlroots/__init__.py
@@ -50,3 +50,13 @@ class PtrHasData(Ptr):
         """Store the given data on the current object"""
         self._data_handle = ffi.new_handle(data)
         self._ptr.data = self._data_handle
+
+
+def str_or_none(member: ffi.CData) -> Optional[str]:
+    """
+    Helper function to check struct members for ffi.NULL, returning None, or a char
+    array, returning a string.
+    """
+    if member:
+        return ffi.string(member).decode()
+    return None

--- a/wlroots/wlr_types/output.py
+++ b/wlroots/wlr_types/output.py
@@ -6,7 +6,7 @@ from typing import Tuple, Optional
 from pywayland.server import Signal
 from pywayland.protocol.wayland import WlOutput
 
-from wlroots import ffi, PtrHasData, lib, Ptr
+from wlroots import ffi, PtrHasData, lib, Ptr, str_or_none
 from wlroots.util.region import PixmanRegion32
 from .matrix import Matrix
 
@@ -44,28 +44,26 @@ class Output(PtrHasData):
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         """The name of the output"""
-        return ffi.string(self._ptr.name).decode()
+        return str_or_none(self._ptr.name)
 
     @property
     def description(self) -> Optional[str]:
         """The description of the output"""
-        if self._ptr.description == ffi.NULL:
-            return None
-        return ffi.string(self._ptr.description).decode()
+        return str_or_none(self._ptr.description)
 
     @property
-    def make(self) -> str:
-        return ffi.string(self._ptr.make).decode()
+    def make(self) -> Optional[str]:
+        return str_or_none(self._ptr.make)
 
     @property
-    def model(self) -> str:
-        return ffi.string(self._ptr.model).decode()
+    def model(self) -> Optional[str]:
+        return str_or_none(self._ptr.model)
 
     @property
-    def serial(self) -> str:
-        return ffi.string(self._ptr.serial).decode()
+    def serial(self) -> Optional[str]:
+        return str_or_none(self._ptr.serial)
 
     @property
     def physical_size_mm(self) -> Tuple[int, int]:

--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, Tuple, TypeVar
 
 from pywayland.server import Display, Signal
 
-from wlroots import ffi, PtrHasData, lib, Ptr
+from wlroots import ffi, PtrHasData, lib, Ptr, str_or_none
 from wlroots.util.edges import Edges
 from .box import Box
 from .output import Output
@@ -209,14 +209,14 @@ class XdgTopLevel(Ptr):
         self.set_app_id_event = Signal(ptr=ffi.addressof(self._ptr.events.set_app_id))
 
     @property
-    def title(self) -> str:
+    def title(self) -> Optional[str]:
         """The title of the toplevel object"""
-        return ffi.string(self._ptr.title).decode()
+        return str_or_none(self._ptr.title)
 
     @property
-    def app_id(self) -> str:
+    def app_id(self) -> Optional[str]:
         """The app id of the toplevel object"""
-        return ffi.string(self._ptr.app_id).decode()
+        return str_or_none(self._ptr.app_id)
 
 
 class XdgTopLevelMoveEvent(Ptr):


### PR DESCRIPTION
This makes char array struct members that are exposed as class
properties return None when they are a null pointer, rather than
erroring on `ffi.string(ffi.NULL)`.