### PR TITLE
Add interface for wlr_primary_selection_v1

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -779,6 +779,24 @@ struct wlr_event_pointer_pinch_end {
 };
 """
 
+# types/wlr_primary_selection_v1.h
+CDEF += """
+struct wlr_primary_selection_v1_device_manager {
+    struct wl_global *global;
+    struct wl_list devices;
+
+    struct wl_listener display_destroy;
+
+    struct {
+        struct wl_signal destroy;
+    } events;
+
+    void *data;
+};
+struct wlr_primary_selection_v1_device_manager *
+    wlr_primary_selection_v1_device_manager_create(struct wl_display *display);
+"""
+
 # types/wlr_screencopy_v1.h
 CDEF += """
 struct wlr_screencopy_manager_v1 {
@@ -1603,6 +1621,7 @@ SOURCE = """
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output_management_v1.h>
+#include <wlr/types/wlr_primary_selection_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_seat.h>

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -18,6 +18,7 @@ from .pointer import (  # noqa: F401
     PointerEventMotion,
     PointerEventMotionAbsolute,
 )
+from .primary_selection_v1 import PrimarySelectionV1DeviceManager  # noqa: F401
 from .screencopy_v1 import ScreencopyManagerV1  # noqa: F401
 from .seat import Seat  # noqa: F401
 from .surface import Surface, SurfaceState  # noqa: F401

--- a/wlroots/wlr_types/primary_selection_v1.py
+++ b/wlroots/wlr_types/primary_selection_v1.py
@@ -1,0 +1,15 @@
+# Copyright (c) Matt Colligan 2021
+
+from pywayland.server import Display
+
+from wlroots import lib, Ptr
+
+
+class PrimarySelectionV1DeviceManager(Ptr):
+    def __init__(self, display: Display) -> None:
+        """Data manager to handle the primary selection
+
+        :param display:
+            The display to handle the clipboard for
+        """
+        self._ptr = lib.wlr_primary_selection_v1_device_manager_create(display._ptr)


### PR DESCRIPTION
This adds PrimarySelectionV1DeviceManager to represent and wrap the
wlroots function wlr_primary_selection_v1_device_manager_create, which
implements a primary selection clipboard used by clients such as some
terminals.