### PR TITLE
Expose input device libinput handles

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -31,6 +31,12 @@ struct wlr_renderer *wlr_backend_get_renderer(struct wlr_backend *backend);
 struct wlr_session *wlr_backend_get_session(struct wlr_backend *backend);
 """
 
+# backend/libinput.h
+CDEF += """
+struct libinput_device *wlr_libinput_get_device_handle(struct wlr_input_device *dev);
+bool wlr_input_device_is_libinput(struct wlr_input_device *device);
+"""
+
 # backend/session.h
 CDEF += """
 bool wlr_session_change_vt(struct wlr_session *session, unsigned vt);
@@ -1608,6 +1614,7 @@ CDEF += """
 SOURCE = """
 #include <wlr/backend.h>
 #include <wlr/backend/headless.h>
+#include <wlr/backend/libinput.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_compositor.h>

--- a/wlroots/wlr_types/input_device.py
+++ b/wlroots/wlr_types/input_device.py
@@ -2,6 +2,7 @@
 
 import enum
 import weakref
+from typing import Optional
 
 from .keyboard import Keyboard
 from wlroots import ffi, PtrHasData, lib
@@ -55,3 +56,14 @@ class InputDevice(PtrHasData):
         _weakkeydict[keyboard] = self._ptr
 
         return keyboard
+
+    def libinput_get_device_handle(self) -> Optional[ffi.CData]:
+        """
+        Returns the underlying libinput device if there is one.
+
+        Returns a pointer to a `struct libinput_device` for use by libinput-interfacing
+        code.
+        """
+        if lib.wlr_input_device_is_libinput(self._ptr):
+            return lib.wlr_libinput_get_device_handle(self._ptr)
+        return None


### PR DESCRIPTION
This adds two functions from backend/libinput.h that are used to get the
libinput device handles from wlr_input_devices. These can be used to
configure these input devices using libinput-interfacing code.