### PR TITLE
Add is_headless properties to Output and Backend

### DIFF
--- a/wlroots/backend.py
+++ b/wlroots/backend.py
@@ -99,6 +99,10 @@ class Backend(Ptr):
     def get_session(self) -> "Session":
         return Session(self)
 
+    @property
+    def is_headless(self) -> bool:
+        return lib.wlr_backend_is_headless(self._ptr)
+
 
 class Session:
     def __init__(self, backend: Backend) -> None:

--- a/wlroots/wlr_types/output.py
+++ b/wlroots/wlr_types/output.py
@@ -242,6 +242,10 @@ class Output(PtrHasData):
         """
         return lib.wlr_output_test(self._ptr)
 
+    @property
+    def is_headless(self) -> bool:
+        return lib.wlr_output_is_headless(self._ptr)
+
 
 class OutputMode(Ptr):
     def __init__(self, ptr) -> None:


### PR DESCRIPTION
These are properties return True when wlroots is running headlessly.