### PR TITLE
Add wlr_xdg_surface_configure and corresponding events

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -1540,6 +1540,14 @@ struct wlr_xdg_surface {
     ...;
 };
 
+struct wlr_xdg_surface_configure {
+    struct wlr_xdg_surface *surface;
+    struct wl_list link; // wlr_xdg_surface::configure_list
+    uint32_t serial;
+
+    struct wlr_xdg_toplevel_state *toplevel_state;
+};
+
 struct wlr_xdg_toplevel_move_event {
     struct wlr_xdg_surface *surface;
     struct wlr_seat_client *seat;

--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -68,6 +68,14 @@ class XdgSurface(PtrHasData):
         self.new_popup_event = Signal(
             ptr=ffi.addressof(self._ptr.events.new_popup), data_wrapper=XdgPopup
         )
+        self.configure_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.configure),
+            data_wrapper=XdgSurfaceConfigure,
+        )
+        self.ack_configure_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.ack_configure),
+            data_wrapper=XdgSurfaceConfigure,
+        )
 
     @classmethod
     def from_surface(cls, surface: Surface) -> "XdgSurface":
@@ -171,6 +179,20 @@ class XdgSurface(PtrHasData):
         lib.wlr_xdg_surface_for_each_surface(
             self._ptr, lib.surface_iterator_callback, handle
         )
+
+
+class XdgSurfaceConfigure(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_xdg_surface_configure *", ptr)
+
+    @property
+    def surface(self) -> XdgSurface:
+        # TODO: keep weakref
+        return XdgSurface(self._ptr.surface)
+
+    @property
+    def serial(self) -> int:
+        return self._ptr.serial
 
 
 class XdgTopLevel(Ptr):


### PR DESCRIPTION
This adds the `wlr_xdg_surface_configure` struct, which is emitted by
xdg toplevels as part of their `configure` and `ack_configure` events.
These can be used by compositors to synchronise state changes with
clients.