### PR TITLE
Use new type syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [pypy3, "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.7", "3.7", "3.8", "3.9", "3.10"]
         wlroots-version: ["0.15.0"]
         include:
           - python-version: "3.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ packages = find:
 python_requires >= 3.7
 install_requires =
   cffi >= 1.12.0
-  dataclasses; python_version < '3.7'
   pywayland >= 0.1.1
   xkbcommon >= 0.2
 zip_safe = False

--- a/tiny/server.py
+++ b/tiny/server.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import cast, List, Optional, Tuple, TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 from pywayland.server import Display, Listener
 from pywayland.protocol.wayland import WlKeyboard, WlSeat
@@ -81,7 +81,7 @@ class TinywlServer:
 
         # the xdg shell will generate new surfaces
         self._xdg_shell = xdg_shell
-        self.views: List[View] = []
+        self.views: list[View] = []
 
         # new pointing devices are attached to the cursor, and rendered with the manager
         self._cursor = cursor
@@ -89,16 +89,16 @@ class TinywlServer:
 
         # the seat manages the keyboard focus information
         self._seat = seat
-        self.keyboards: List[KeyboardHandler] = []
+        self.keyboards: list[KeyboardHandler] = []
         self.cursor_mode = CursorMode.PASSTHROUGH
-        self.grabbed_view: Optional[View] = None
+        self.grabbed_view: View | None = None
         self.grab_x = 0.0
         self.grab_y = 0.0
-        self.grab_geobox: Optional[Box] = None
+        self.grab_geobox: Box | None = None
         self.resize_edges: Edges = Edges.NONE
 
         self._output_layout = output_layout
-        self.outputs: List[Output] = []
+        self.outputs: list[Output] = []
 
         xdg_shell.new_surface_event.add(Listener(self.server_new_xdg_surface))
 
@@ -117,7 +117,7 @@ class TinywlServer:
 
     def view_at(
         self, layout_x, layout_y
-    ) -> Tuple[Optional[View], Optional[Surface], float, float]:
+    ) -> tuple[View | None, Surface | None, float, float]:
         for view in self.views[::-1]:
             surface, x, y = view.view_at(layout_x, layout_y)
             if surface is not None:
@@ -230,7 +230,7 @@ class TinywlServer:
             return False
         return True
 
-    def focus_view(self, view: View, surface: Optional[Surface] = None) -> None:
+    def focus_view(self, view: View, surface: Surface | None = None) -> None:
         """Focus a given XDG surface
 
         Moves the surface to the front of the list for rendering.  Sets the

--- a/tiny/view.py
+++ b/tiny/view.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from pywayland.server import Listener
 
@@ -99,7 +99,7 @@ class View:
 
     def view_at(
         self, layout_x: int, layout_y: int
-    ) -> Tuple[Optional[Surface], float, float]:
+    ) -> tuple[Surface | None, float, float]:
         view_x = layout_x - self.x
         view_y = layout_y - self.y
         return self.xdg_surface.surface_at(view_x, view_y)

--- a/wlroots/__init__.py
+++ b/wlroots/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) Sean Vig 2018
 
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import Any
 
 from ._ffi import ffi, lib  # noqa: F401
 from .version import version as _version
@@ -40,7 +42,7 @@ class PtrHasData(Ptr):
     """
 
     @property
-    def data(self) -> Optional[Any]:
+    def data(self) -> Any | None:
         """Return any data that has been stored on the object"""
         if self._ptr.data == ffi.NULL:
             return None
@@ -53,7 +55,7 @@ class PtrHasData(Ptr):
         self._ptr.data = self._data_handle
 
 
-def str_or_none(member: ffi.CData) -> Optional[str]:
+def str_or_none(member: ffi.CData) -> str | None:
     """
     Helper function to check struct members for ffi.NULL, returning None, or a char
     array, returning a string.

--- a/wlroots/allocator.py
+++ b/wlroots/allocator.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2022 Sean Vig
 
+from __future__ import annotations
+
 from wlroots import lib, Ptr
 from wlroots.renderer import Renderer
 from wlroots.backend import Backend
@@ -16,7 +18,7 @@ class Allocator(Ptr):
         self._ptr = ptr
 
     @classmethod
-    def autocreate(cls, backend: Backend, renderer: Renderer) -> "Allocator":
+    def autocreate(cls, backend: Backend, renderer: Renderer) -> Allocator:
         """Creates the adequate allocator given a backend and a renderer."""
         ret = lib.wlr_allocator_autocreate(backend._ptr, renderer._ptr)
         if not ret:

--- a/wlroots/backend.py
+++ b/wlroots/backend.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2019 Sean Vig
 
+from __future__ import annotations
+
 import enum
 import weakref
 
@@ -80,7 +82,7 @@ class Backend(Ptr):
             self.destroy()
             raise RuntimeError("Unable to start backend")
 
-    def __enter__(self) -> "Backend":
+    def __enter__(self) -> Backend:
         """Context manager to create and clean-up the backend"""
         self.start()
         return self
@@ -89,7 +91,7 @@ class Backend(Ptr):
         """Destroy the backend on context exit"""
         self.destroy()
 
-    def get_session(self) -> "Session":
+    def get_session(self) -> Session:
         return Session(self)
 
     @property

--- a/wlroots/helper.py
+++ b/wlroots/helper.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2021 Sean Vig
 
-from typing import Tuple
-
 from pywayland.server import Display
 
 from wlroots.allocator import Allocator
@@ -12,7 +10,7 @@ from wlroots.wlr_types import Compositor
 
 def build_compositor(
     display: Display, *, backend_type=BackendType.AUTO
-) -> Tuple[Compositor, Allocator, Renderer, Backend]:
+) -> tuple[Compositor, Allocator, Renderer, Backend]:
     """Build and run a compositor
 
     :param display:

--- a/wlroots/renderer.py
+++ b/wlroots/renderer.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2019 Sean Vig
 
+from __future__ import annotations
+
 import contextlib
-from typing import Iterator, List, Optional, Tuple, Union
+from typing import Iterator, Union
 
 from pywayland.server import Display
 
@@ -10,7 +12,7 @@ from wlroots.backend import Backend
 from wlroots.util.box import Box
 from wlroots.wlr_types import Matrix, Texture
 
-ColorType = Union[List, Tuple, ffi.CData]
+ColorType = Union[list, tuple, ffi.CData]
 
 
 class Renderer(Ptr):
@@ -22,7 +24,7 @@ class Renderer(Ptr):
         self._ptr = ptr
 
     @classmethod
-    def autocreate(cls, backend: Backend) -> "Renderer":
+    def autocreate(cls, backend: Backend) -> Renderer:
         """Creates a suitable renderer for a backend."""
         ret = lib.wlr_renderer_autocreate(backend._ptr)
         if not ret:
@@ -40,7 +42,7 @@ class Renderer(Ptr):
             raise RuntimeError("Unable to initialize renderer for display")
 
     @contextlib.contextmanager
-    def render(self, width: int, height: int) -> Iterator["Renderer"]:
+    def render(self, width: int, height: int) -> Iterator[Renderer]:
         """Render within the generated context"""
         self.begin(width, height)
         try:
@@ -90,7 +92,7 @@ class Renderer(Ptr):
             color = ffi.new("float[4]", color)
         lib.wlr_render_rect(self._ptr, box._ptr, color, projection._ptr)
 
-    def scissor(self, box: Optional[Box]) -> None:
+    def scissor(self, box: Box | None) -> None:
         """
         Defines a scissor box. Only pixels that lie within the scissor box can be
         modified by drawing functions. Providing a NULL `box` disables the scissor

--- a/wlroots/util/box.py
+++ b/wlroots/util/box.py
@@ -1,7 +1,7 @@
 # Copyright Sean Vig (c) 2020
 # Copyright Matt Colligan (c) 2021
 
-from typing import Optional, Tuple
+from __future__ import annotations
 
 from wlroots import ffi, lib
 
@@ -23,10 +23,10 @@ def _int_setter(attr):
 class Box:
     def __init__(
         self,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        x: int | None = None,
+        y: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
         ptr=None,
     ) -> None:
         """A simple box structure, represented by a coordinate and dimensions"""
@@ -49,10 +49,10 @@ class Box:
     width = property(_int_getter("width"), _int_setter("width"))
     height = property(_int_getter("height"), _int_setter("height"))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Box(%s, %s, %s, %s)" % (self.x, self.y, self.width, self.height)
 
-    def closest_point(self, x: float, y: float) -> Tuple[float, float]:
+    def closest_point(self, x: float, y: float) -> tuple[float, float]:
         xy_ptr = ffi.new("double[2]")
         lib.wlr_box_closest_point(self._ptr, x, y, xy_ptr, xy_ptr + 1)
         return xy_ptr[0], xy_ptr[1]

--- a/wlroots/util/clock.py
+++ b/wlroots/util/clock.py
@@ -1,5 +1,7 @@
 # Copyright Sean Vig (c) 2020
 
+from __future__ import annotations
+
 from wlroots import ffi, lib, Ptr
 
 
@@ -9,7 +11,7 @@ class Timespec(Ptr):
         self._ptr = ptr
 
     @classmethod
-    def get_monotonic_time(cls) -> "Timespec":
+    def get_monotonic_time(cls) -> Timespec:
         """Get the current monotonic time"""
         timespec = ffi.new("struct timespec *")
         ret = lib.clock_gettime(lib.CLOCK_MONOTONIC, timespec)

--- a/wlroots/util/region.py
+++ b/wlroots/util/region.py
@@ -1,6 +1,6 @@
 # Copyright (c) Matt Colligan 2021
 
-from typing import List
+from __future__ import annotations
 
 from pywayland.protocol.wayland import WlOutput
 from wlroots import ffi, lib, Ptr
@@ -19,7 +19,7 @@ class PixmanRegion32(Ptr):
         else:
             self._ptr = ptr
 
-    def __enter__(self) -> "PixmanRegion32":
+    def __enter__(self) -> PixmanRegion32:
         """Use the pixman_region32 in a context manager"""
         lib.pixman_region32_init(self._ptr)
         return self
@@ -28,7 +28,7 @@ class PixmanRegion32(Ptr):
         """Finish up when exiting the context"""
         lib.pixman_region32_fini(self._ptr)
 
-    def rectangles_as_boxes(self) -> List[Box]:
+    def rectangles_as_boxes(self) -> list[Box]:
         nrects_ptr = ffi.new("int *")
         rects = lib.pixman_region32_rectangles(self._ptr, nrects_ptr)
         nrects = nrects_ptr[0]
@@ -43,7 +43,7 @@ class PixmanRegion32(Ptr):
 
     def transform(
         self,
-        src: "PixmanRegion32",
+        src: PixmanRegion32,
         transform: WlOutput.transform,
         width: int,
         height: int,

--- a/wlroots/wlr_types/compositor.py
+++ b/wlroots/wlr_types/compositor.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2019 Sean Vig
 
+from __future__ import annotations
+
 from pywayland.server import Display
 from typing import TYPE_CHECKING
 
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class Compositor(Ptr):
-    def __init__(self, display: Display, renderer: "Renderer") -> None:
+    def __init__(self, display: Display, renderer: Renderer) -> None:
         """A compositor for clients to be able to allocate surfaces
 
         :param display:

--- a/wlroots/wlr_types/cursor.py
+++ b/wlroots/wlr_types/cursor.py
@@ -1,7 +1,7 @@
 # Copyright (c) Sean Vig 2019
+from __future__ import annotations
 
 import enum
-from typing import Optional, Tuple
 
 from pywayland.server import Signal
 
@@ -151,7 +151,7 @@ class Cursor(PtrHasData):
         delta_x: float,
         delta_y: float,
         *,
-        input_device: Optional[InputDevice] = None,
+        input_device: InputDevice | None = None,
     ) -> None:
         """Move the cursor in the direction of the given x and y layout coordinates
 
@@ -170,10 +170,10 @@ class Cursor(PtrHasData):
     def warp(
         self,
         warp_mode: WarpMode,
-        x: Optional[float],
-        y: Optional[float],
+        x: float | None,
+        y: float | None,
         *,
-        input_device: Optional[InputDevice] = None,
+        input_device: InputDevice | None = None,
     ) -> bool:
         """Warp the cursor to the given x and y in location
 
@@ -213,8 +213,8 @@ class Cursor(PtrHasData):
             raise ValueError("Invalid warp mode")
 
     def absolute_to_layout_coords(
-        self, input_device: Optional[InputDevice], x: float, y: float
-    ) -> Tuple[float, float]:
+        self, input_device: InputDevice | None, x: float, y: float
+    ) -> tuple[float, float]:
         """Convert absolute 0..1 coordinates to layout coordinates
 
         The `input_device` may be passed to respect device mapping constraints.
@@ -233,7 +233,7 @@ class Cursor(PtrHasData):
 
         return xy_ptr[0], xy_ptr[1]
 
-    def set_surface(self, surface: Optional[Surface], hotspot: Tuple[int, int]) -> None:
+    def set_surface(self, surface: Surface | None, hotspot: tuple[int, int]) -> None:
         """Set the cursor surface
 
         The surface can be committed to update the cursor image. The surface
@@ -247,7 +247,7 @@ class Cursor(PtrHasData):
 
         lib.wlr_cursor_set_surface(self._ptr, surface_ptr, hotspot[0], hotspot[1])
 
-    def __enter__(self) -> "Cursor":
+    def __enter__(self) -> Cursor:
         """Context manager to clean up the cursor"""
         return self
 

--- a/wlroots/wlr_types/foreign_toplevel_management_v1.py
+++ b/wlroots/wlr_types/foreign_toplevel_management_v1.py
@@ -1,5 +1,7 @@
 # Copyright (c) Matt Colligan 2021
 
+from __future__ import annotations
+
 import enum
 from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
@@ -11,8 +13,6 @@ from .output import Output
 from .surface import Surface
 
 if TYPE_CHECKING:
-    from typing import Optional
-
     from pywayland.server import Display
 
 _weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
@@ -33,12 +33,12 @@ class ForeignToplevelManagerV1(PtrHasData):
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
     @classmethod
-    def create(cls, display: "Display") -> "ForeignToplevelManagerV1":
+    def create(cls, display: Display) -> ForeignToplevelManagerV1:
         """Create a wlr_foreign_toplevel_manager_v1 for the given display."""
         ptr = lib.wlr_foreign_toplevel_manager_v1_create(display._ptr)
         return cls(ptr)
 
-    def create_handle(self) -> "ForeignToplevelHandleV1":
+    def create_handle(self) -> ForeignToplevelHandleV1:
         """Create a new wlr_foreign_toplevel_handle_v1."""
         ptr = lib.wlr_foreign_toplevel_handle_v1_create(self._ptr)
         return ForeignToplevelHandleV1(ptr)
@@ -81,19 +81,19 @@ class ForeignToplevelHandleV1(PtrHasData):
         return ForeignToplevelManagerV1(manager_ptr)
 
     @property
-    def title(self) -> "Optional[str]":
+    def title(self) -> str | None:
         if self._ptr.title == ffi.NULL:
             return None
         return ffi.string(self._ptr.title).decode()
 
     @property
-    def app_id(self) -> "Optional[str]":
+    def app_id(self) -> str | None:
         if self._ptr.app_id == ffi.NULL:
             return None
         return ffi.string(self._ptr.app_id).decode()
 
     @property
-    def parent(self) -> "Optional[ForeignToplevelHandleV1]":
+    def parent(self) -> ForeignToplevelHandleV1 | None:
         if self._ptr.parent == ffi.NULL:
             return None
         return ForeignToplevelHandleV1(self._ptr.parent)
@@ -107,10 +107,10 @@ class ForeignToplevelHandleV1(PtrHasData):
     def set_app_id(self, app_id: str) -> None:
         lib.wlr_foreign_toplevel_handle_v1_set_app_id(self._ptr, app_id.encode())
 
-    def output_enter(self, output: "Output") -> None:
+    def output_enter(self, output: Output) -> None:
         lib.wlr_foreign_toplevel_handle_v1_output_enter(self._ptr, output._ptr)
 
-    def output_leave(self, output: "Output") -> None:
+    def output_leave(self, output: Output) -> None:
         lib.wlr_foreign_toplevel_handle_v1_output_leave(self._ptr, output._ptr)
 
     def set_maximized(self, maximized: bool) -> None:
@@ -125,7 +125,7 @@ class ForeignToplevelHandleV1(PtrHasData):
     def set_fullscreen(self, fullscreen: bool) -> None:
         lib.wlr_foreign_toplevel_handle_v1_set_fullscreen(self._ptr, fullscreen)
 
-    def set_parent(self, parent: "ForeignToplevelHandleV1") -> None:
+    def set_parent(self, parent: ForeignToplevelHandleV1) -> None:
         lib.wlr_foreign_toplevel_handle_v1_set_parent(self._ptr, parent._ptr)
 
 
@@ -183,7 +183,7 @@ class ForeignToplevelHandleV1FullscreenEvent(_EventBase):
         return self._ptr.fullscreen
 
     @property
-    def output(self) -> "Output":
+    def output(self) -> Output:
         """The output on which to fullscreen this toplevel."""
         return Output(self._ptr.output)
 

--- a/wlroots/wlr_types/input_device.py
+++ b/wlroots/wlr_types/input_device.py
@@ -1,8 +1,8 @@
 # Copyright (c) Sean Vig 2019
+from __future__ import annotations
 
 import enum
 import weakref
-from typing import Optional
 
 from .keyboard import Keyboard
 from wlroots import ffi, PtrHasData, lib
@@ -69,7 +69,7 @@ class InputDevice(PtrHasData):
 
         return keyboard
 
-    def libinput_get_device_handle(self) -> Optional[ffi.CData]:
+    def libinput_get_device_handle(self) -> ffi.CData | None:
         """
         Returns the underlying libinput device if there is one.
 

--- a/wlroots/wlr_types/keyboard.py
+++ b/wlroots/wlr_types/keyboard.py
@@ -1,5 +1,7 @@
 # Copyright Sean Vig (c) 2020
 
+from __future__ import annotations
+
 import enum
 from weakref import WeakKeyDictionary
 
@@ -106,7 +108,7 @@ class Keyboard(PtrHasData):
         return self._ptr.num_keycodes
 
     @property
-    def modifiers(self) -> "KeyboardModifiers":
+    def modifiers(self) -> KeyboardModifiers:
         """The modifiers associated with the keyboard"""
         modifiers_ptr = ffi.addressof(self._ptr.modifiers)
         _weakkeydict[modifiers_ptr] = self._ptr

--- a/wlroots/wlr_types/layer_shell_v1.py
+++ b/wlroots/wlr_types/layer_shell_v1.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2021 Matt Colligan
+from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
 
 from pywayland.server import Signal
@@ -106,7 +107,7 @@ class LayerSurfaceV1(PtrHasData):
         return Surface(surface_ptr)
 
     @property
-    def output(self) -> Optional[Output]:
+    def output(self) -> Output | None:
         output_ptr = self._ptr.output
         if output_ptr == ffi.NULL:
             return None
@@ -159,7 +160,7 @@ class LayerSurfaceV1(PtrHasData):
         return LayerSurfaceV1(surface_ptr)
 
     def for_each_surface(
-        self, iterator: SurfaceCallback[T], data: Optional[T] = None
+        self, iterator: SurfaceCallback[T], data: T | None = None
     ) -> None:
         """
         Calls the iterator function for each sub-surface and popup of this surface
@@ -170,9 +171,7 @@ class LayerSurfaceV1(PtrHasData):
             self._ptr, lib.surface_iterator_callback, handle
         )
 
-    def surface_at(
-        self, sx: float, sy: float
-    ) -> Tuple[Optional[Surface], float, float]:
+    def surface_at(self, sx: float, sy: float) -> tuple[Surface | None, float, float]:
         """
         Find a surface within this layer-surface tree at the given surface-local
         coordinates. Returns the surface and coordinates in the leaf surface
@@ -190,7 +189,7 @@ class LayerSurfaceV1(PtrHasData):
 
 
 class LayerShellV1(PtrHasData):
-    def __init__(self, display: "Display") -> None:
+    def __init__(self, display: Display) -> None:
         """Create an wlr_xdg_output_manager_v1"""
         self._ptr = lib.wlr_layer_shell_v1_create(display._ptr)
 

--- a/wlroots/wlr_types/matrix.py
+++ b/wlroots/wlr_types/matrix.py
@@ -1,5 +1,7 @@
 # Copyright Sean Vig (c) 2020
 
+from __future__ import annotations
+
 from pywayland.protocol.wayland import WlOutput
 
 from wlroots import ffi, lib, Ptr
@@ -12,7 +14,7 @@ class Matrix(Ptr):
         self._ptr = ptr
 
     @classmethod
-    def identity(cls) -> "Matrix":
+    def identity(cls) -> Matrix:
         """An identity matrix"""
         mat_ptr = cls._build_matrix_ptr()
         lib.wlr_matrix_identity(mat_ptr)
@@ -21,7 +23,7 @@ class Matrix(Ptr):
     @classmethod
     def projection(
         cls, width: int, height: int, transform: WlOutput.transform
-    ) -> "Matrix":
+    ) -> Matrix:
         """A 2d orthographic projection matrix of (width, height) with specified transform"""
         mat_ptr = cls._build_matrix_ptr()
         lib.wlr_matrix_projection(mat_ptr, width, height, transform)
@@ -33,8 +35,8 @@ class Matrix(Ptr):
         box: Box,
         transform: WlOutput.transform,
         rotation: float,
-        projection: "Matrix",
-    ) -> "Matrix":
+        projection: Matrix,
+    ) -> Matrix:
         """Project the specified box onto a orthographic projection with a rotation"""
         mat_ptr = cls._build_matrix_ptr()
         lib.wlr_matrix_project_box(
@@ -42,7 +44,7 @@ class Matrix(Ptr):
         )
         return Matrix(mat_ptr)
 
-    def transpose(self) -> "Matrix":
+    def transpose(self) -> Matrix:
         """Transpose the matrix"""
         mat_ptr = self._build_matrix_ptr()
         lib.wlr_matrix_transpose(mat_ptr, self._ptr)
@@ -64,7 +66,7 @@ class Matrix(Ptr):
         """Apply the given transformation to the matrix"""
         lib.wlr_matrix_transform(self._ptr, transform)
 
-    def __matmul__(self, other: "Matrix") -> "Matrix":
+    def __matmul__(self, other: Matrix) -> Matrix:
         """Perform matrix multiplication with given matrix"""
         mat_ptr = self._build_matrix_ptr()
         lib.wlr_matrix_multiply(mat_ptr, self._ptr, other._ptr)

--- a/wlroots/wlr_types/output.py
+++ b/wlroots/wlr_types/output.py
@@ -1,7 +1,9 @@
 # Copyright (c) Sean Vig 2019
 # Copyright (c) Matt Colligan 2021
 
-from typing import Tuple, Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from pywayland.server import Signal
 from pywayland.protocol.wayland import WlOutput
@@ -48,29 +50,29 @@ class Output(PtrHasData):
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         """The name of the output"""
         return str_or_none(self._ptr.name)
 
     @property
-    def description(self) -> Optional[str]:
+    def description(self) -> str | None:
         """The description of the output"""
         return str_or_none(self._ptr.description)
 
     @property
-    def make(self) -> Optional[str]:
+    def make(self) -> str | None:
         return str_or_none(self._ptr.make)
 
     @property
-    def model(self) -> Optional[str]:
+    def model(self) -> str | None:
         return str_or_none(self._ptr.model)
 
     @property
-    def serial(self) -> Optional[str]:
+    def serial(self) -> str | None:
         return str_or_none(self._ptr.serial)
 
     @property
-    def physical_size_mm(self) -> Tuple[int, int]:
+    def physical_size_mm(self) -> tuple[int, int]:
         """Returns the width and height of the output, in millimeters"""
         return self._ptr.phys_width, self._ptr.phys_height
 
@@ -84,7 +86,7 @@ class Output(PtrHasData):
         return self._ptr.enabled
 
     @property
-    def current_mode(self) -> "OutputMode":
+    def current_mode(self) -> OutputMode:
         return OutputMode(self._ptr.current_mode)
 
     @property
@@ -107,7 +109,7 @@ class Output(PtrHasData):
         """
         lib.wlr_output_enable(self._ptr, enable)
 
-    def preferred_mode(self) -> Optional["OutputMode"]:
+    def preferred_mode(self) -> OutputMode | None:
         """Returns the preferred mode for this output
 
         If the output doesn't support modes, returns None.
@@ -118,7 +120,7 @@ class Output(PtrHasData):
 
         return OutputMode(output_mode_ptr)
 
-    def set_mode(self, mode: "OutputMode") -> None:
+    def set_mode(self, mode: OutputMode) -> None:
         """Sets the output mode
 
         The output needs to be enabled.
@@ -137,7 +139,7 @@ class Output(PtrHasData):
         """Create the global corresponding to the output"""
         lib.wlr_output_create_global(self._ptr)
 
-    def __enter__(self) -> "Output":
+    def __enter__(self) -> Output:
         """Start rendering frame"""
         return self
 
@@ -148,7 +150,7 @@ class Output(PtrHasData):
         else:
             self.rollback()
 
-    def init_render(self, allocator: "Allocator", renderer: "Renderer") -> None:
+    def init_render(self, allocator: Allocator, renderer: Renderer) -> None:
         """Initialize the output's rendering subsystem with the provided allocator and renderer.
 
         Can only be called once.
@@ -187,7 +189,7 @@ class Output(PtrHasData):
         """Discard the pending output state"""
         lib.wlr_output_rollback(self._ptr)
 
-    def effective_resolution(self) -> Tuple[int, int]:
+    def effective_resolution(self) -> tuple[int, int]:
         """Computes the transformed and scaled output resolution"""
         width_ptr = ffi.new("int *")
         height_ptr = ffi.new("int *")
@@ -196,7 +198,7 @@ class Output(PtrHasData):
         height = height_ptr[0]
         return width, height
 
-    def transformed_resolution(self) -> Tuple[int, int]:
+    def transformed_resolution(self) -> tuple[int, int]:
         """Computes the transformed output resolution"""
         width_ptr = ffi.new("int *")
         height_ptr = ffi.new("int *")
@@ -205,7 +207,7 @@ class Output(PtrHasData):
         height = height_ptr[0]
         return width, height
 
-    def render_software_cursors(self, damage: Optional[PixmanRegion32] = None) -> None:
+    def render_software_cursors(self, damage: PixmanRegion32 | None = None) -> None:
         """Renders software cursors
 
         This is a utility function that can be called when compositors render.

--- a/wlroots/wlr_types/output_layout.py
+++ b/wlroots/wlr_types/output_layout.py
@@ -1,6 +1,6 @@
 # Copyright (c) Sean Vig 2019
 
-from typing import Optional, Tuple
+from __future__ import annotations
 
 from pywayland.server import Signal
 
@@ -44,7 +44,7 @@ class OutputLayout(Ptr):
         """
         lib.wlr_output_layout_add_auto(self._ptr, output._ptr)
 
-    def output_coords(self, output: Output) -> Tuple[float, float]:
+    def output_coords(self, output: Output) -> tuple[float, float]:
         """Determine coordinates of the output in the layout
 
         Given x and y in layout coordinates, adjusts them to local output
@@ -56,7 +56,7 @@ class OutputLayout(Ptr):
 
         return ox[0], oy[0]
 
-    def __enter__(self) -> "OutputLayout":
+    def __enter__(self) -> OutputLayout:
         """Use the output layout in a context manager"""
         return self
 
@@ -64,7 +64,7 @@ class OutputLayout(Ptr):
         """Clean up the output layout when exiting the context"""
         self.destroy()
 
-    def output_at(self, x: float, y: float) -> Optional[Output]:
+    def output_at(self, x: float, y: float) -> Output | None:
         """
         Get the output at the specified layout coordinates. Returns None if no output
         matches the coordinates.
@@ -89,7 +89,7 @@ class OutputLayout(Ptr):
         """Remove an output from the layout."""
         lib.wlr_output_layout_remove(self._ptr, output._ptr)
 
-    def get_box(self, reference: Optional[Output] = None) -> Box:
+    def get_box(self, reference: Output | None = None) -> Box:
         """
         Get the box of the layout for the given reference output in layout
         coordinates. If `reference` is None, the box will be for the extents of the
@@ -102,8 +102,8 @@ class OutputLayout(Ptr):
         return Box(ptr=box_ptr)
 
     def closest_point(
-        self, lx: float, ly: float, reference: Optional[Output] = None
-    ) -> Tuple[float, float]:
+        self, lx: float, ly: float, reference: Output | None = None
+    ) -> tuple[float, float]:
         """
         Get the closest point on this layout from the given point from the reference
         output. If reference is NULL, gets the closest point from the entire layout.

--- a/wlroots/wlr_types/output_management_v1.py
+++ b/wlroots/wlr_types/output_management_v1.py
@@ -1,4 +1,5 @@
 # Copyright (c) Matt Colligan 2021
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Iterator
@@ -141,7 +142,7 @@ class OutputConfigurationHeadV1(Ptr):
     @classmethod
     def create(
         cls, config: OutputConfigurationV1, output: Output
-    ) -> "OutputConfigurationHeadV1":
+    ) -> OutputConfigurationHeadV1:
         """Create a new wlr_output_configuration_head_v1"""
         ptr = lib.wlr_output_configuration_head_v1_create(config._ptr, output._ptr)
         return OutputConfigurationHeadV1(ptr)

--- a/wlroots/wlr_types/pointer_constraints_v1.py
+++ b/wlroots/wlr_types/pointer_constraints_v1.py
@@ -1,7 +1,9 @@
 # Copyright (c) Matt Colligan 2021
 
+from __future__ import annotations
+
 import enum
-import typing
+from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
 
 from pywayland.server import Signal
@@ -10,7 +12,7 @@ from wlroots import ffi, lib, Ptr
 from .surface import Surface
 from wlroots.util.region import PixmanRegion32
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from pywayland.server import Display
 
 _weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
@@ -27,7 +29,7 @@ class PointerConstraintV1StateField(enum.IntEnum):
 
 
 class PointerConstraintsV1(Ptr):
-    def __init__(self, display: "Display") -> None:
+    def __init__(self, display: Display) -> None:
         """Manager to handle pointer constraint requests.
 
         :param display:
@@ -67,20 +69,20 @@ class PointerConstraintV1(Ptr):
         return Surface(surface_ptr)
 
     @property
-    def type(self) -> "PointerConstraintV1Type":
+    def type(self) -> PointerConstraintV1Type:
         return PointerConstraintV1Type(self._ptr.type)
 
     @property
-    def region(self) -> "PixmanRegion32":
+    def region(self) -> PixmanRegion32:
         region_ptr = ffi.addressof(self._ptr, "region")
         return PixmanRegion32(region_ptr)
 
     @property
-    def current(self) -> "PointerConstraintV1State":
+    def current(self) -> PointerConstraintV1State:
         return PointerConstraintV1State(self._ptr.current)
 
     @property
-    def pending(self) -> "PointerConstraintV1State":
+    def pending(self) -> PointerConstraintV1State:
         return PointerConstraintV1State(self._ptr.pending)
 
 
@@ -89,13 +91,13 @@ class PointerConstraintV1State(Ptr):
         self._ptr = ptr
 
     @property
-    def committed(self) -> "PointerConstraintV1StateField":
+    def committed(self) -> PointerConstraintV1StateField:
         return PointerConstraintV1StateField(self._ptr.committed)
 
     @property
-    def region(self) -> "PixmanRegion32":
+    def region(self) -> PixmanRegion32:
         return PixmanRegion32(self._ptr.region)
 
     @property
-    def cursor_hint(self) -> typing.Tuple[float, float]:
+    def cursor_hint(self) -> tuple[float, float]:
         return self._ptr.cursor_hint.x, self._ptr.cursor_hint.y

--- a/wlroots/wlr_types/relative_pointer_manager_v1.py
+++ b/wlroots/wlr_types/relative_pointer_manager_v1.py
@@ -1,5 +1,7 @@
 # Copyright (c) Matt Colligan 2021
 
+from __future__ import annotations
+
 import typing
 
 from pywayland.server import Signal
@@ -13,7 +15,7 @@ if typing.TYPE_CHECKING:
 
 
 class RelativePointerManagerV1(Ptr):
-    def __init__(self, display: "Display") -> None:
+    def __init__(self, display: Display) -> None:
         """A global interface used for getting the relative pointer object for a given
         pointer.
 
@@ -32,7 +34,7 @@ class RelativePointerManagerV1(Ptr):
 
     def send_relative_motion(
         self,
-        seat: "Seat",
+        seat: Seat,
         time_usec: int,
         dx: float,
         dy: float,

--- a/wlroots/wlr_types/scene.py
+++ b/wlroots/wlr_types/scene.py
@@ -1,5 +1,7 @@
 # Copyright (c) Sean Vig 2022
 
+from __future__ import annotations
+
 import weakref
 
 from wlroots import ffi, lib, PtrHasData, Ptr
@@ -18,13 +20,13 @@ class Scene(Ptr):
             raise RuntimeError("Unable to attach scene to output layout")
 
     @property
-    def node(self) -> "SceneNode":
+    def node(self) -> SceneNode:
         """The associated scene node."""
         node = SceneNode(ffi.addressof(self._ptr.node))
         _weakkeydict[node] = self._ptr
         return node
 
-    def get_scene_output(self, output: Output) -> "SceneOutput":
+    def get_scene_output(self, output: Output) -> SceneOutput:
         """Get a scene-graph output from a wlr_output."""
         ptr = lib.wlr_scene_get_scene_output(self._ptr, output._ptr)
         return SceneOutput(ptr)
@@ -57,8 +59,8 @@ class SceneNode(PtrHasData):
 
     @classmethod
     def xdg_surface_create(
-        cls, parent: "SceneNode", xdg_surface: XdgSurface
-    ) -> "SceneNode":
+        cls, parent: SceneNode, xdg_surface: XdgSurface
+    ) -> SceneNode:
         """Add a node displaying an xdg_surface and all of its sub-surfaces to the scene-graph.
 
         The origin of the returned scene-graph node will match the top-left
@@ -79,10 +81,10 @@ class SceneNode(PtrHasData):
         """Move the node below all of its sibling nodes."""
         lib.wlr_scene_node_lower_to_bottom(self._ptr)
 
-    def place_above(self, sibling: "SceneNode") -> None:
+    def place_above(self, sibling: SceneNode) -> None:
         """Move the node right above the specified sibling."""
         lib.wlr_scene_node_place_above(self._ptr, sibling._ptr)
 
-    def place_below(self, sibling: "SceneNode") -> None:
+    def place_below(self, sibling: SceneNode) -> None:
         """Move the node right below the specified sibling."""
         lib.wlr_scene_node_place_below(self._ptr, sibling._ptr)

--- a/wlroots/wlr_types/screencopy_v1.py
+++ b/wlroots/wlr_types/screencopy_v1.py
@@ -6,7 +6,7 @@ from wlroots import ffi, PtrHasData, lib
 
 
 class ScreencopyManagerV1(PtrHasData):
-    def __init__(self, display: "Display") -> None:
+    def __init__(self, display: Display) -> None:
         """Create a wlr_screencopy_manager_v1"""
         self._ptr = lib.wlr_screencopy_manager_v1_create(display._ptr)
 

--- a/wlroots/wlr_types/seat.py
+++ b/wlroots/wlr_types/seat.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2019 Sean Vig
 
-from typing import Optional, Tuple
+from __future__ import annotations
+
 from weakref import WeakKeyDictionary
 
 from pywayland.server import Display, Signal
@@ -17,12 +18,12 @@ _weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
 
 
 class KeyboardGrab(Ptr):
-    def __init__(self, seat: "Seat") -> None:
+    def __init__(self, seat: Seat) -> None:
         """Setup the keyboard grab"""
         self._ptr = ffi.new("struct wlr_seat_keyboard_grab *")
         self._seat = seat
 
-    def __enter__(self) -> "KeyboardGrab":
+    def __enter__(self) -> KeyboardGrab:
         """State the keyboard grab"""
         lib.wlr_seat_keyboard_start_grab(self._seat._ptr, self._ptr)
         return self
@@ -100,14 +101,14 @@ class Seat(PtrHasData):
         )
 
     @property
-    def pointer_state(self) -> "SeatPointerState":
+    def pointer_state(self) -> SeatPointerState:
         """The pointer state associated with the seat"""
         pointer_state_ptr = ffi.addressof(self._ptr.pointer_state)
         _weakkeydict[pointer_state_ptr] = self._ptr
         return SeatPointerState(pointer_state_ptr)
 
     @property
-    def keyboard_state(self) -> "SeatKeyboardState":
+    def keyboard_state(self) -> SeatKeyboardState:
         """The keyboard state associated with the seat"""
         keyboard_state_ptr = ffi.addressof(self._ptr.keyboard_state)
         _weakkeydict[keyboard_state_ptr] = self._ptr
@@ -340,7 +341,7 @@ class Seat(PtrHasData):
         """
         lib.wlr_seat_start_pointer_drag(self._ptr, drag._ptr, serial)
 
-    def __enter__(self) -> "Seat":
+    def __enter__(self) -> Seat:
         """Context manager to clean up the seat"""
         return self
 
@@ -365,7 +366,7 @@ class PointerRequestSetCursorEvent(Ptr):
         return self._ptr.serial
 
     @property
-    def hotspot(self) -> Tuple[int, int]:
+    def hotspot(self) -> tuple[int, int]:
         return self._ptr.hotspot_x, self._ptr.hotspot_y
 
 
@@ -433,7 +434,7 @@ class SeatPointerState(Ptr):
         )
 
     @property
-    def focused_surface(self) -> Optional[Surface]:
+    def focused_surface(self) -> Surface | None:
         """The surface that currently has keyboard focus"""
         focused_surface = self._ptr.focused_surface
         if focused_surface == ffi.NULL:
@@ -452,7 +453,7 @@ class SeatKeyboardState(Ptr):
         )
 
     @property
-    def focused_surface(self) -> Optional[Surface]:
+    def focused_surface(self) -> Surface | None:
         """The surface that is currently focused"""
         focused_surface = self._ptr.focused_surface
         if focused_surface == ffi.NULL:

--- a/wlroots/wlr_types/server_decoration.py
+++ b/wlroots/wlr_types/server_decoration.py
@@ -3,6 +3,8 @@
 # This protocol is obsolete and will be removed in a future version. The recommended
 # replacement is xdg-decoration.
 
+from __future__ import annotations
+
 import enum
 from typing import TYPE_CHECKING
 
@@ -27,7 +29,7 @@ class ServerDecorationManager(PtrHasData):
         self._ptr = ptr
 
     @classmethod
-    def create(cls, display: "Display") -> "ServerDecorationManager":
+    def create(cls, display: Display) -> ServerDecorationManager:
         """Create a wlr_server_decoration_manager for the given display."""
         ptr = lib.wlr_server_decoration_manager_create(display._ptr)
         return cls(ptr)

--- a/wlroots/wlr_types/surface.py
+++ b/wlroots/wlr_types/surface.py
@@ -1,5 +1,7 @@
 # Copyright Sean Vig (c) 2020
 
+from __future__ import annotations
+
 from weakref import WeakKeyDictionary
 
 from pywayland.protocol.wayland import WlOutput
@@ -56,14 +58,14 @@ class Surface(PtrHasData):
         return self._ptr.sy
 
     @property
-    def current(self) -> "SurfaceState":
+    def current(self) -> SurfaceState:
         """The current commited surface state"""
         current_ptr = self._ptr.current
         _weakkeydict[current_ptr] = self._ptr
         return SurfaceState(current_ptr)
 
     @property
-    def previous(self) -> "SurfaceState":
+    def previous(self) -> SurfaceState:
         """The state of the previous commit"""
         previous_ptr = self._ptr.previous
         _weakkeydict[previous_ptr] = self._ptr

--- a/wlroots/wlr_types/texture.py
+++ b/wlroots/wlr_types/texture.py
@@ -1,6 +1,7 @@
 # Copyright (c) Sean Vig 2020
 # Copyright (c) Matt Colligan 2021
 
+from __future__ import annotations
 
 import typing
 
@@ -17,13 +18,13 @@ class Texture(Ptr):
     @classmethod
     def from_pixels(
         cls,
-        renderer: "Renderer",
+        renderer: Renderer,
         fmt: int,
         stride: int,
         width: int,
         height: int,
         data: ffi.CData,
-    ) -> "Texture":
+    ) -> Texture:
         """
         Create a new texture from raw pixel data. `stride` is in bytes. The returned
         texture is mutable.

--- a/wlroots/wlr_types/xdg_decoration_v1.py
+++ b/wlroots/wlr_types/xdg_decoration_v1.py
@@ -1,5 +1,7 @@
 # Copyright (c) Matt Colligan 2021
 
+from __future__ import annotations
+
 import enum
 from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
@@ -33,7 +35,7 @@ class XdgDecorationManagerV1(PtrHasData):
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
     @classmethod
-    def create(cls, display: "Display"):
+    def create(cls, display: Display):
         """Create a wlr_xdg_decoration_manager_v1 for the given display."""
         ptr = lib.wlr_xdg_decoration_manager_v1_create(display._ptr)
         return cls(ptr)

--- a/wlroots/wlr_types/xdg_output_v1.py
+++ b/wlroots/wlr_types/xdg_output_v1.py
@@ -7,7 +7,7 @@ from .output_layout import OutputLayout
 
 
 class XdgOutputManagerV1(Ptr):
-    def __init__(self, display: "Display", layout: "OutputLayout") -> None:
+    def __init__(self, display: Display, layout: OutputLayout) -> None:
         """Create an wlr_xdg_output_manager_v1"""
         self._ptr = lib.wlr_xdg_output_manager_v1_create(display._ptr, layout._ptr)
 

--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -1,8 +1,10 @@
 # Copyright (c) Sean Vig 2019
 
+from __future__ import annotations
+
 import enum
 import weakref
-from typing import Callable, Optional, Tuple, TypeVar
+from typing import Callable, TypeVar
 
 from pywayland.server import Display, Signal
 
@@ -78,7 +80,7 @@ class XdgSurface(PtrHasData):
         )
 
     @classmethod
-    def from_surface(cls, surface: Surface) -> "XdgSurface":
+    def from_surface(cls, surface: Surface) -> XdgSurface:
         """Get the xdg surface associated with the given surface"""
         if not surface.is_xdg_surface:
             raise RuntimeError("Surface is not XDG surface")
@@ -96,7 +98,7 @@ class XdgSurface(PtrHasData):
         return XdgSurfaceRole(self._ptr.role)
 
     @property
-    def toplevel(self) -> "XdgTopLevel":
+    def toplevel(self) -> XdgTopLevel:
         """Return the top level xdg object
 
         This shell must be a top level role
@@ -113,7 +115,7 @@ class XdgSurface(PtrHasData):
         return toplevel
 
     @property
-    def popup(self) -> "XdgPopup":
+    def popup(self) -> XdgPopup:
         """Return the popup xdg object
 
         This shell must be a popup role.
@@ -158,7 +160,7 @@ class XdgSurface(PtrHasData):
 
     def surface_at(
         self, surface_x: float, surface_y: float
-    ) -> Tuple[Optional[Surface], float, float]:
+    ) -> tuple[Surface | None, float, float]:
         """Find a surface within this xdg-surface tree at the given surface-local coordinates
 
         Returns the surface and coordinates in the leaf surface coordinate
@@ -175,7 +177,7 @@ class XdgSurface(PtrHasData):
         return Surface(surface_ptr), sub_x_data[0], sub_y_data[0]
 
     def for_each_surface(
-        self, iterator: SurfaceCallback[T], data: Optional[T] = None
+        self, iterator: SurfaceCallback[T], data: T | None = None
     ) -> None:
         """Call iterator on each surface and popup in the xdg-surface tree
 
@@ -245,7 +247,7 @@ class XdgTopLevel(Ptr):
         self.set_app_id_event = Signal(ptr=ffi.addressof(self._ptr.events.set_app_id))
 
     @property
-    def parent(self) -> Optional[XdgSurface]:
+    def parent(self) -> XdgSurface | None:
         """The surface of the parent of this toplevel"""
         parent_ptr = self._ptr.parent
         if parent_ptr is None:
@@ -253,12 +255,12 @@ class XdgTopLevel(Ptr):
         return XdgSurface(parent_ptr)
 
     @property
-    def title(self) -> Optional[str]:
+    def title(self) -> str | None:
         """The title of the toplevel object"""
         return str_or_none(self._ptr.title)
 
     @property
-    def app_id(self) -> Optional[str]:
+    def app_id(self) -> str | None:
         """The app id of the toplevel object"""
         return str_or_none(self._ptr.app_id)
 


### PR DESCRIPTION
Modify the type annotations to use the new Python 3.10 syntax for types,
in particular using the "X | Y" union types and using the builtin
generic types rather than the `typing` equivalents.  Without adding a
lot of quoted type annotations (which would make this a net negative
change, IMO), this requires dropping Python 3.6 support to be able to
use the `__future__` annotations functionality.