### PR TITLE
Add wlr_relative_pointer_v1

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -933,6 +933,40 @@ struct wlr_primary_selection_v1_device_manager *
     wlr_primary_selection_v1_device_manager_create(struct wl_display *display);
 """
 
+# types/wlr_relative_pointer_v1.h
+CDEF += """
+struct wlr_relative_pointer_manager_v1 {
+    struct wl_global *global;
+    struct wl_list relative_pointers; // wlr_relative_pointer_v1::link
+
+    struct {
+        struct wl_signal destroy;
+        struct wl_signal new_relative_pointer; // wlr_relative_pointer_v1
+    } events;
+    ...;
+};
+
+struct wlr_relative_pointer_v1 {
+    struct wl_resource *resource;
+    struct wl_resource *pointer_resource;
+    struct wlr_seat *seat;
+    struct wl_list link; // wlr_relative_pointer_manager_v1::relative_pointers
+
+    struct {
+        struct wl_signal destroy;
+    } events;
+    ...;
+};
+
+struct wlr_relative_pointer_manager_v1 *wlr_relative_pointer_manager_v1_create(
+    struct wl_display *display);
+
+void wlr_relative_pointer_manager_v1_send_relative_motion(
+    struct wlr_relative_pointer_manager_v1 *manager, struct wlr_seat *seat,
+    uint64_t time_usec, double dx, double dy,
+    double dx_unaccel, double dy_unaccel);
+"""
+
 # types/wlr_screencopy_v1.h
 CDEF += """
 struct wlr_screencopy_manager_v1 {
@@ -1772,6 +1806,7 @@ SOURCE = """
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_primary_selection_v1.h>
+#include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_seat.h>

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -21,6 +21,7 @@ from .pointer import (  # noqa: F401
 )
 from .pointer_constraints_v1 import PointerContraintsV1, PointerContraintV1  # noqa: F401
 from .primary_selection_v1 import PrimarySelectionV1DeviceManager  # noqa: F401
+from .relative_pointer_manager_v1 import RelativePointerManagerV1  # noqa: F401
 from .screencopy_v1 import ScreencopyManagerV1  # noqa: F401
 from .seat import Seat  # noqa: F401
 from .surface import Surface, SurfaceState  # noqa: F401

--- a/wlroots/wlr_types/relative_pointer_manager_v1.py
+++ b/wlroots/wlr_types/relative_pointer_manager_v1.py
@@ -1,0 +1,52 @@
+# Copyright (c) Matt Colligan 2021
+
+import typing
+
+from pywayland.server import Signal
+
+from wlroots import Ptr, ffi, lib
+
+if typing.TYPE_CHECKING:
+    from pywayland.server import Display
+
+    from .seat import Seat
+
+
+class RelativePointerManagerV1(Ptr):
+    def __init__(self, display: "Display") -> None:
+        """A global interface used for getting the relative pointer object for a given
+        pointer.
+
+        :param display:
+            The display to manage relative pointer events on.
+        """
+        self._ptr = lib.wlr_relative_pointer_manager_v1_create(display._ptr)
+
+        self.destroy_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.destroy),
+        )
+        self.new_relative_pointer_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.new_relative_pointer),
+            data_wrapper=RelativePointerV1,
+        )
+
+    def send_relative_motion(
+        self,
+        seat: "Seat",
+        time_usec: int,
+        dx: float,
+        dy: float,
+        dx_unaccel: float,
+        dy_unaccel: float,
+    ) -> None:
+        lib.wlr_relative_pointer_manager_v1_send_relative_motion(
+            self._ptr, seat._ptr, time_usec, dx, dy, dx_unaccel, dy_unaccel
+        )
+
+
+class RelativePointerV1(Ptr):
+    def __init__(self, ptr) -> None:
+        """A `struct wlr_relative_pointer_v1` instance."""
+        self._ptr = ffi.cast("struct wlr_relative_pointer_v1 *", ptr)
+
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))


### PR DESCRIPTION
This adds some of the code from wlroots' wlr_relative_pointer_v1.h so
that compositors can use the relative_pointer_v1 protocol.