### PR TITLE
Redirect internal Box import

### DIFF
--- a/tiny/view.py
+++ b/tiny/view.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple, TYPE_CHECKING
 
 from pywayland.server import Listener
 
-from wlroots.wlr_types import Box
+from wlroots.util.box import Box
 from wlroots.util.edges import Edges
 from .cursor_mode import CursorMode
 

--- a/wlroots/renderer.py
+++ b/wlroots/renderer.py
@@ -6,7 +6,8 @@ from typing import Iterator, List, Optional, Tuple, Union
 from pywayland.server import Display
 
 from wlroots import ffi, lib, Ptr
-from wlroots.wlr_types import Box, Matrix, Texture
+from wlroots.util.box import Box
+from wlroots.wlr_types import Matrix, Texture
 
 ColorType = Union[List, Tuple, ffi.CData]
 

--- a/wlroots/util/region.py
+++ b/wlroots/util/region.py
@@ -4,7 +4,7 @@ from typing import List
 
 from pywayland.protocol.wayland import WlOutput
 from wlroots import ffi, lib, Ptr
-from wlroots.wlr_types.box import Box
+from wlroots.util.box import Box
 
 
 class PixmanRegion32(Ptr):

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2019 Sean Vig
 
-from .box import Box  # noqa: F401
 from .compositor import Compositor  # noqa: F401
 from .cursor import Cursor  # noqa: F401
 from .data_control_v1 import DataControlManagerV1  # noqa: F401
@@ -30,3 +29,14 @@ from .xcursor_manager import XCursorManager  # noqa: F401
 from .xdg_decoration_v1 import XdgDecorationManagerV1  # noqa: F401
 from .xdg_output_v1 import XdgOutputManagerV1  # noqa: F401
 from .xdg_shell import XdgShell  # noqa: F401
+
+
+def __getattr__(name: str):
+    if name == "Box":
+        from .box import Box  # noqa: F401
+
+        return Box
+    try:
+        return globals()[name]
+    except KeyError:
+        raise ImportError(f"cannot import name '{name}' from wlroots.wlr_types")

--- a/wlroots/wlr_types/matrix.py
+++ b/wlroots/wlr_types/matrix.py
@@ -3,7 +3,7 @@
 from pywayland.protocol.wayland import WlOutput
 
 from wlroots import ffi, lib, Ptr
-from .box import Box
+from wlroots.util.box import Box
 
 
 class Matrix(Ptr):

--- a/wlroots/wlr_types/output_damage.py
+++ b/wlroots/wlr_types/output_damage.py
@@ -3,8 +3,8 @@
 from pywayland.server import Signal
 
 from wlroots import ffi, lib, Ptr
+from wlroots.util.box import Box
 from wlroots.util.region import PixmanRegion32
-from .box import Box
 from .output import Output
 
 

--- a/wlroots/wlr_types/output_layout.py
+++ b/wlroots/wlr_types/output_layout.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 from pywayland.server import Signal
 
 from wlroots import ffi, lib, Ptr
-from .box import Box
+from wlroots.util.box import Box
 from .output import Output
 
 

--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -7,8 +7,8 @@ from typing import Callable, Optional, Tuple, TypeVar
 from pywayland.server import Display, Signal
 
 from wlroots import ffi, PtrHasData, lib, Ptr, str_or_none
+from wlroots.util.box import Box
 from wlroots.util.edges import Edges
-from .box import Box
 from .output import Output
 from .surface import Surface
 


### PR DESCRIPTION
This stops pywlroots from emitting the warning itself when `wlr_types`
is being imported correctly.