### PR TITLE
Add wlr_input_inhibit_manager for screen locking

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -326,6 +326,29 @@ struct wlr_input_device {
 };
 """
 
+# types/wlr_input_inhibitor.h
+CDEF += """
+struct wlr_input_inhibit_manager {
+    struct wl_global *global;
+    struct wl_client *active_client;
+    struct wl_resource *active_inhibitor;
+
+    struct wl_listener display_destroy;
+
+    struct {
+        struct wl_signal activate;   // struct wlr_input_inhibit_manager *
+        struct wl_signal deactivate; // struct wlr_input_inhibit_manager *
+        struct wl_signal destroy;
+    } events;
+
+    void *data;
+    ...;
+};
+
+struct wlr_input_inhibit_manager *wlr_input_inhibit_manager_create(
+    struct wl_display *display);
+"""
+
 # types/wlr_keyboard.h
 CDEF += """
 #define WLR_LED_COUNT 3
@@ -1796,6 +1819,7 @@ SOURCE = """
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
+#include <wlr/types/wlr_input_inhibitor.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_linux_dmabuf_v1.h>

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -6,6 +6,7 @@ from .data_control_v1 import DataControlManagerV1  # noqa: F401
 from .data_device_manager import DataDeviceManager  # noqa: F401
 from .gamma_control_v1 import GammaControlManagerV1  # noqa: F401
 from .input_device import InputDevice  # noqa: F401
+from .input_inhibit import InputInhibitManager  # noqa: F401
 from .keyboard import Keyboard  # noqa: F401
 from .layer_shell_v1 import LayerShellV1  # noqa: F401
 from .matrix import Matrix  # noqa: F401

--- a/wlroots/wlr_types/input_inhibit.py
+++ b/wlroots/wlr_types/input_inhibit.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 Graeme Holliday
+
+from pywayland.server import Display, Signal
+
+from wlroots import ffi, Ptr, lib
+
+
+class InputInhibitManager(Ptr):
+    def __init__(self, display: Display) -> None:
+        """Creates a wlr_input_inhibit_manager"""
+        self._ptr = lib.wlr_input_inhibit_manager_create(display._ptr)
+
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+
+    def is_inactive(self) -> bool:
+        return not self._ptr.active_inhibitor


### PR DESCRIPTION
Adds bindings to `wlr_input_inhibit_manager`, which allows programs such as swaylock or waylock to prevent sneaky input sequences, improving screen locking security.

Implementation details are left to the compositor--in fact, as long as a `wlr_input_inhibit_manager` exists, swaylock (e.g.) will assume that it is implemented correctly.
