### PR TITLE
Add some touch event handling to the seat

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -1279,6 +1279,14 @@ bool wlr_seat_pointer_has_grab(struct wlr_seat *seat);
 void wlr_seat_set_keyboard(struct wlr_seat *seat, struct wlr_input_device *dev);
 struct wlr_keyboard *wlr_seat_get_keyboard(struct wlr_seat *seat);
 
+uint32_t wlr_seat_touch_notify_down(struct wlr_seat *seat,
+    struct wlr_surface *surface, uint32_t time_msec,
+    int32_t touch_id, double sx, double sy);
+void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time_msec,
+    int32_t touch_id);
+void wlr_seat_touch_notify_motion(struct wlr_seat *seat, uint32_t time_msec,
+    int32_t touch_id, double sx, double sy);
+
 void wlr_seat_keyboard_start_grab(struct wlr_seat *wlr_seat,
     struct wlr_seat_keyboard_grab *grab);
 void wlr_seat_keyboard_end_grab(struct wlr_seat *wlr_seat);

--- a/wlroots/wlr_types/cursor.py
+++ b/wlroots/wlr_types/cursor.py
@@ -21,6 +21,12 @@ from .pointer import (
     PointerEventSwipeUpdate,
 )
 from .surface import Surface
+from .touch import (
+    TouchEventUp,
+    TouchEventDown,
+    TouchEventMotion,
+    TouchEventCancel,
+)
 
 
 class WarpMode(enum.Enum):
@@ -82,6 +88,23 @@ class Cursor(PtrHasData):
         self.pinch_end = Signal(
             ptr=ffi.addressof(self._ptr.events.pinch_end),
             data_wrapper=PointerEventPinchEnd,
+        )
+
+        self.touch_up_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.touch_up),
+            data_wrapper=TouchEventUp,
+        )
+        self.touch_down_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.touch_down),
+            data_wrapper=TouchEventDown,
+        )
+        self.touch_motion_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.touch_motion),
+            data_wrapper=TouchEventMotion,
+        )
+        self.touch_cancel_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.touch_cancel),
+            data_wrapper=TouchEventCancel,
         )
 
     @property

--- a/wlroots/wlr_types/seat.py
+++ b/wlroots/wlr_types/seat.py
@@ -58,6 +58,13 @@ class Seat(PtrHasData):
             ptr=ffi.addressof(self._ptr.events.keyboard_grab_end)
         )
 
+        self.touch_grab_begin_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.touch_grab_begin)
+        )
+        self.touch_grab_end_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.touch_grab_end)
+        )
+
         self.request_set_cursor_event = Signal(
             ptr=ffi.addressof(self._ptr.events.request_set_cursor),
             data_wrapper=PointerRequestSetCursorEvent,
@@ -273,6 +280,41 @@ class Seat(PtrHasData):
     def keyboard_has_grab(self) -> bool:
         """Whether or not the keyboard has a grab other than the default grab"""
         return lib.wlr_seat_keyboard_has_grab(self._ptr)
+
+    def touch_notify_down(
+        self,
+        surface: Surface,
+        time_msec: int,
+        touch_id: int,
+        surface_x: float,
+        surface_y: float,
+    ) -> None:
+        """
+        Notify the seat of a touch down on the given surface. Defers to any grab of the
+        touch device.
+        """
+        lib.wlr_seat_touch_notify_down(
+            self._ptr, surface._ptr, time_msec, touch_id, surface_x, surface_y
+        )
+
+    def touch_notify_up(self, time_msec: int, touch_id: int) -> None:
+        """
+        Notify the seat that the touch point given by `touch_id` is up. Defers to any
+        grab of the touch device.
+        """
+        lib.wlr_seat_touch_notify_up(self._ptr, time_msec, touch_id)
+
+    def touch_notify_motion(
+        self, time_msec: int, touch_id: int, surface_x: float, surface_y: float
+    ) -> None:
+        """
+        Notify the seat that the touch point given by `touch_id` has moved. Defers to
+        any grab of the touch device. The seat should be notified of touch motion even
+        if the surface is not the owner of the touch point for processing by grabs.
+        """
+        lib.wlr_seat_touch_notify_motion(
+            self._ptr, time_msec, touch_id, surface_x, surface_y
+        )
 
     def set_selection(self, source, serial: int) -> None:
         """Sets the current selection for the seat

--- a/wlroots/wlr_types/touch.py
+++ b/wlroots/wlr_types/touch.py
@@ -1,0 +1,88 @@
+# Copyright (c) Matt Colligan 2021
+
+from wlroots import ffi, Ptr
+from .input_device import InputDevice
+
+
+class TouchEventUp(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_event_touch_up *", ptr)
+
+    @property
+    def device(self) -> InputDevice:
+        return InputDevice(self._ptr.device)
+
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def touch_id(self) -> int:
+        return self._ptr.touch_id
+
+
+class TouchEventDown(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_event_touch_down *", ptr)
+
+    @property
+    def device(self) -> InputDevice:
+        return InputDevice(self._ptr.device)
+
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def touch_id(self) -> int:
+        return self._ptr.touch_id
+
+    @property
+    def x(self) -> float:
+        return self._ptr.x
+
+    @property
+    def y(self) -> float:
+        return self._ptr.y
+
+
+class TouchEventMotion(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_event_touch_motion *", ptr)
+
+    @property
+    def device(self) -> InputDevice:
+        return InputDevice(self._ptr.device)
+
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def touch_id(self) -> int:
+        return self._ptr.touch_id
+
+    @property
+    def x(self) -> float:
+        return self._ptr.x
+
+    @property
+    def y(self) -> float:
+        return self._ptr.y
+
+
+class TouchEventCancel(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_event_touch_cancel *", ptr)
+
+    @property
+    def device(self) -> InputDevice:
+        return InputDevice(self._ptr.device)
+
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def touch_id(self) -> int:
+        return self._ptr.touch_id


### PR DESCRIPTION
This adds some basic touch event methods to for wlr_seat, as well as the
touch events from wlr_touch.h. These can be used for compositors to
receive touch events.