### PR TITLE
Add some handlers for wlr_foreign_toplevel_management_v1

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -329,6 +329,100 @@ struct wlr_data_source {
 void wlr_data_source_destroy(struct wlr_data_source *source);
 """
 
+# types/wlr_foreign_toplevel_management_v1.h
+CDEF += """
+struct wlr_foreign_toplevel_manager_v1 {
+    struct wl_event_loop *event_loop;
+    struct wl_global *global;
+    struct wl_list resources; // wl_resource_get_link
+    struct wl_list toplevels; // wlr_foreign_toplevel_handle_v1::link
+
+    struct wl_listener display_destroy;
+
+    struct {
+        struct wl_signal destroy;
+    } events;
+
+    void *data;
+    ...;
+};
+
+struct wlr_foreign_toplevel_handle_v1 {
+    struct wlr_foreign_toplevel_manager_v1 *manager;
+    struct wl_list resources;
+    struct wl_list link;
+    struct wl_event_source *idle_source;
+
+    char *title;
+    char *app_id;
+    struct wlr_foreign_toplevel_handle_v1 *parent;
+    struct wl_list outputs; // wlr_foreign_toplevel_v1_output
+    uint32_t state; // wlr_foreign_toplevel_v1_state
+
+    struct {
+        struct wl_signal request_maximize;
+        struct wl_signal request_minimize;
+        struct wl_signal request_activate;
+        struct wl_signal request_fullscreen;
+        struct wl_signal request_close;
+        struct wl_signal set_rectangle;
+        struct wl_signal destroy;
+    } events;
+
+    void *data;
+    ...;
+};
+
+struct wlr_foreign_toplevel_handle_v1_maximized_event {
+    struct wlr_foreign_toplevel_handle_v1 *toplevel;
+    bool maximized;
+};
+struct wlr_foreign_toplevel_handle_v1_minimized_event {
+    struct wlr_foreign_toplevel_handle_v1 *toplevel;
+    bool minimized;
+};
+struct wlr_foreign_toplevel_handle_v1_activated_event {
+    struct wlr_foreign_toplevel_handle_v1 *toplevel;
+    struct wlr_seat *seat;
+};
+struct wlr_foreign_toplevel_handle_v1_fullscreen_event {
+    struct wlr_foreign_toplevel_handle_v1 *toplevel;
+    bool fullscreen;
+    struct wlr_output *output;
+};
+struct wlr_foreign_toplevel_handle_v1_set_rectangle_event {
+    struct wlr_foreign_toplevel_handle_v1 *toplevel;
+    struct wlr_surface *surface;
+    int32_t x, y, width, height;
+};
+
+struct wlr_foreign_toplevel_manager_v1 *wlr_foreign_toplevel_manager_v1_create(
+    struct wl_display *display);
+struct wlr_foreign_toplevel_handle_v1 *wlr_foreign_toplevel_handle_v1_create(
+    struct wlr_foreign_toplevel_manager_v1 *manager);
+void wlr_foreign_toplevel_handle_v1_destroy(
+    struct wlr_foreign_toplevel_handle_v1 *toplevel);
+void wlr_foreign_toplevel_handle_v1_set_title(
+    struct wlr_foreign_toplevel_handle_v1 *toplevel, const char *title);
+void wlr_foreign_toplevel_handle_v1_set_app_id(
+    struct wlr_foreign_toplevel_handle_v1 *toplevel, const char *app_id);
+void wlr_foreign_toplevel_handle_v1_output_enter(
+    struct wlr_foreign_toplevel_handle_v1 *toplevel, struct wlr_output *output);
+void wlr_foreign_toplevel_handle_v1_output_leave(
+    struct wlr_foreign_toplevel_handle_v1 *toplevel, struct wlr_output *output);
+void wlr_foreign_toplevel_handle_v1_set_maximized(
+    struct wlr_foreign_toplevel_handle_v1 *toplevel, bool maximized);
+void wlr_foreign_toplevel_handle_v1_set_minimized(
+    struct wlr_foreign_toplevel_handle_v1 *toplevel, bool minimized);
+void wlr_foreign_toplevel_handle_v1_set_activated(
+    struct wlr_foreign_toplevel_handle_v1 *toplevel, bool activated);
+void wlr_foreign_toplevel_handle_v1_set_fullscreen(
+    struct wlr_foreign_toplevel_handle_v1* toplevel, bool fullscreen);
+void wlr_foreign_toplevel_handle_v1_set_parent(
+    struct wlr_foreign_toplevel_handle_v1 *toplevel,
+    struct wlr_foreign_toplevel_handle_v1 *parent);
+"""
+
 # types/wlr_gamma_control_v1.h
 CDEF += """
 struct wlr_gamma_control_manager_v1 {
@@ -1919,6 +2013,7 @@ SOURCE = """
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_data_device.h>
+#include <wlr/types/wlr_foreign_toplevel_management_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_input_inhibitor.h>
 #include <wlr/types/wlr_keyboard.h>

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -4,6 +4,7 @@ from .compositor import Compositor  # noqa: F401
 from .cursor import Cursor  # noqa: F401
 from .data_control_v1 import DataControlManagerV1  # noqa: F401
 from .data_device_manager import DataDeviceManager  # noqa: F401
+from .foreign_toplevel_management_v1 import ForeignToplevelManagerV1  # noqa: F401
 from .gamma_control_v1 import GammaControlManagerV1  # noqa: F401
 from .input_device import InputDevice  # noqa: F401
 from .input_inhibit import InputInhibitManager  # noqa: F401

--- a/wlroots/wlr_types/foreign_toplevel_management_v1.py
+++ b/wlroots/wlr_types/foreign_toplevel_management_v1.py
@@ -1,0 +1,218 @@
+# Copyright (c) Matt Colligan 2021
+
+import enum
+from typing import TYPE_CHECKING
+from weakref import WeakKeyDictionary
+
+from pywayland.server import Signal
+
+from wlroots import ffi, Ptr, PtrHasData, lib
+from .output import Output
+from .surface import Surface
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from pywayland.server import Display
+
+_weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
+
+
+class ForeignToplevelHandleV1State(enum.IntEnum):
+    MAXIMIZED = 1 << 0
+    MINIMIZED = 1 << 1
+    ACTIVATED = 1 << 2
+    FULLSCREEN = 1 << 3
+
+
+class ForeignToplevelManagerV1(PtrHasData):
+    def __init__(self, ptr) -> None:
+        """An foreign toplevel manager: wlr_foreign_toplevel_manager_v1."""
+        self._ptr = ffi.cast("struct wlr_foreign_toplevel_manager_v1 *", ptr)
+
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+
+    @classmethod
+    def create(cls, display: "Display") -> "ForeignToplevelManagerV1":
+        """Create a wlr_foreign_toplevel_manager_v1 for the given display."""
+        ptr = lib.wlr_foreign_toplevel_manager_v1_create(display._ptr)
+        return cls(ptr)
+
+    def create_handle(self) -> "ForeignToplevelHandleV1":
+        """Create a new wlr_foreign_toplevel_handle_v1."""
+        ptr = lib.wlr_foreign_toplevel_handle_v1_create(self._ptr)
+        return ForeignToplevelHandleV1(ptr)
+
+
+class ForeignToplevelHandleV1(PtrHasData):
+    def __init__(self, ptr) -> None:
+        """struct wlr_foreign_toplevel_handle_v1"""
+        self._ptr = ffi.cast("struct wlr_foreign_toplevel_handle_v1 *", ptr)
+
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+        self.request_maximize_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_maximize),
+            data_wrapper=ForeignToplevelHandleV1MaximizedEvent,
+        )
+        self.request_minimize_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_minimize),
+            data_wrapper=ForeignToplevelHandleV1MinimizedEvent,
+        )
+        self.request_activate_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_activate),
+            data_wrapper=ForeignToplevelHandleV1ActivatedEvent,
+        )
+        self.request_fullscreen_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_fullscreen),
+            data_wrapper=ForeignToplevelHandleV1FullscreenEvent,
+        )
+        self.request_close_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_close)
+        )
+        self.set_rectangle_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.set_rectangle),
+            data_wrapper=ForeignToplevelHandleV1SetRectangleEvent,
+        )
+
+    @property
+    def manager(self) -> ForeignToplevelManagerV1:
+        manager_ptr = self._ptr.manager
+        _weakkeydict[manager_ptr] = self._ptr
+        return ForeignToplevelManagerV1(manager_ptr)
+
+    @property
+    def title(self) -> "Optional[str]":
+        if self._ptr.title == ffi.NULL:
+            return None
+        return ffi.string(self._ptr.title).decode()
+
+    @property
+    def app_id(self) -> "Optional[str]":
+        if self._ptr.app_id == ffi.NULL:
+            return None
+        return ffi.string(self._ptr.app_id).decode()
+
+    @property
+    def parent(self) -> "Optional[ForeignToplevelHandleV1]":
+        if self._ptr.parent == ffi.NULL:
+            return None
+        return ForeignToplevelHandleV1(self._ptr.parent)
+
+    def destroy(self) -> None:
+        lib.wlr_foreign_toplevel_handle_v1_destroy(self._ptr)
+
+    def set_title(self, title: str) -> None:
+        lib.wlr_foreign_toplevel_handle_v1_set_title(self._ptr, title.encode())
+
+    def set_app_id(self, app_id: str) -> None:
+        lib.wlr_foreign_toplevel_handle_v1_set_app_id(self._ptr, app_id.encode())
+
+    def output_enter(self, output: "Output") -> None:
+        lib.wlr_foreign_toplevel_handle_v1_output_enter(self._ptr, output._ptr)
+
+    def output_leave(self, output: "Output") -> None:
+        lib.wlr_foreign_toplevel_handle_v1_output_leave(self._ptr, output._ptr)
+
+    def set_maximized(self, maximized: bool) -> None:
+        lib.wlr_foreign_toplevel_handle_v1_set_maximized(self._ptr, maximized)
+
+    def set_minimized(self, minimized: bool) -> None:
+        lib.wlr_foreign_toplevel_handle_v1_set_minimized(self._ptr, minimized)
+
+    def set_activated(self, activated: bool) -> None:
+        lib.wlr_foreign_toplevel_handle_v1_set_activated(self._ptr, activated)
+
+    def set_fullscreen(self, fullscreen: bool) -> None:
+        lib.wlr_foreign_toplevel_handle_v1_set_fullscreen(self._ptr, fullscreen)
+
+    def set_parent(self, parent: "ForeignToplevelHandleV1") -> None:
+        lib.wlr_foreign_toplevel_handle_v1_set_parent(self._ptr, parent._ptr)
+
+
+class _EventBase(Ptr):
+    @property
+    def toplevel(self) -> ForeignToplevelHandleV1:
+        """The toplevel handle associated with this event."""
+        return ForeignToplevelHandleV1(self._ptr.toplevel)
+
+
+class ForeignToplevelHandleV1MaximizedEvent(_EventBase):
+    def __init__(self, ptr) -> None:
+        """Event emitted when a maximize state change is requested."""
+        self._ptr = ffi.cast(
+            "struct wlr_foreign_toplevel_handle_v1_maximized_event *", ptr
+        )
+
+    @property
+    def maximized(self) -> bool:
+        """The requested state."""
+        return self._ptr.maximized
+
+
+class ForeignToplevelHandleV1MinimizedEvent(_EventBase):
+    def __init__(self, ptr) -> None:
+        """Event emitted when a minimize state change is requested."""
+        self._ptr = ffi.cast(
+            "struct wlr_foreign_toplevel_handle_v1_minimized_event *", ptr
+        )
+
+    @property
+    def minimized(self) -> bool:
+        """The requested state."""
+        return self._ptr.minimized
+
+
+class ForeignToplevelHandleV1ActivatedEvent(_EventBase):
+    def __init__(self, ptr) -> None:
+        """Event emitted when activation of a toplevel is requested."""
+        self._ptr = ffi.cast(
+            "struct wlr_foreign_toplevel_handle_v1_activated_event *", ptr
+        )
+
+
+class ForeignToplevelHandleV1FullscreenEvent(_EventBase):
+    def __init__(self, ptr) -> None:
+        """Event emitted when a fullscreen state change is requested."""
+        self._ptr = ffi.cast(
+            "struct wlr_foreign_toplevel_handle_v1_fullscreen_event *", ptr
+        )
+
+    @property
+    def fullscreen(self) -> bool:
+        """The requested state."""
+        return self._ptr.fullscreen
+
+    @property
+    def output(self) -> "Output":
+        """The output on which to fullscreen this toplevel."""
+        return Output(self._ptr.output)
+
+
+class ForeignToplevelHandleV1SetRectangleEvent(_EventBase):
+    def __init__(self, ptr) -> None:
+        """Event emitted when new geometry for a toplevel is requested."""
+        self._ptr = ffi.cast(
+            "struct wlr_foreign_toplevel_handle_v1_set_rectangle_event *", ptr
+        )
+
+    @property
+    def surface(self) -> Surface:
+        surface_ptr = self._ptr.surface
+        _weakkeydict[surface_ptr] = self._ptr
+        return Surface(surface_ptr)
+
+    @property
+    def x(self) -> int:
+        return self._ptr.x
+
+    @property
+    def y(self) -> int:
+        return self._ptr.y
+
+    @property
+    def width(self) -> int:
+        return self._ptr.width
+
+    @property
+    def height(self) -> int:
+        return self._ptr.height


### PR DESCRIPTION
   This adds some code for wlroots' wlr_foreign_toplevel_management_v1
    protocol so that compositors can expose window information and clients
    can get information on other windows.