### PR TITLE
Handle invalid UTF-8 string members

### DIFF
--- a/wlroots/__init__.py
+++ b/wlroots/__init__.py
@@ -59,5 +59,5 @@ def str_or_none(member: ffi.CData) -> Optional[str]:
     array, returning a string.
     """
     if member:
-        return ffi.string(member).decode()
+        return ffi.string(member).decode(errors="backslashreplace")
     return None


### PR DESCRIPTION
Some struct members are meant to be UTF-8 encoded strings, but bugs in
other software (i.e. clients) can cause them to provide invalid UTF-8
strings. This causes `UnicodeDecodeError` to be raised when decoding
these to Python strings. This change prevents these errors so that users
of pywlroots don't all need custom logic for bugs in other software.

--

See https://github.com/qtile/qtile/issues/3161 for more info. Qtile (and other pywlroots-using code) could instead catch the `UnicodeDecodeError` exceptions themselves as an alternative, or they could use `wlroots.ffi.string(obj._member).decode(errors="backslashreplace")` directly to avoid doing so. Thoughts?