### PR TITLE
Add test for helper

### DIFF
--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,0 +1,9 @@
+from pywayland.server import Display
+
+from wlroots.backend import BackendType
+from wlroots.helper import build_compositor
+
+
+def test_build_compositor():
+    with Display() as display:
+        build_compositor(display, backend_type=BackendType.HEADLESS)


### PR DESCRIPTION
Create a test for the helper script. Adding this provides some test coverage here and the import catches the previous problems with types annotations not working for Python versions <3.9.