### PR TITLE
Add xwayland C code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,15 @@ jobs:
             libxcb-dri3-dev \
             libxcb-icccm4-dev \
             libxcb-image0-dev \
+            libxcb-present-dev \
             libxcb-render0-dev \
+            libxcb-res0-dev \
             libxcb-xfixes0-dev \
             libxcb-xinput-dev \
             libxcb1-dev \
             libxkbcommon-dev \
-            ninja-build
+            ninja-build \
+            xwayland
           sudo pip install meson
       - name: Set environment variables
         run: |
@@ -91,7 +94,7 @@ jobs:
       - name: Build wlroots
         working-directory: wlroots-${{ matrix.wlroots-version }}
         run: |
-          meson build --prefix=/usr
+          meson build --prefix=/usr -Dxwayland=enabled
           ninja -C build
           DESTDIR=~/wayland ninja -C build install
       - name: Create artifact
@@ -141,6 +144,7 @@ jobs:
             libxcb-icccm4-dev \
             libxcb-image0-dev \
             libxcb-render0-dev \
+            libxcb-res0-dev \
             libxcb-xfixes0-dev \
             libxcb-xinput-dev \
             libxcb1-dev \

--- a/wlroots/wlr_types/surface.py
+++ b/wlroots/wlr_types/surface.py
@@ -48,6 +48,15 @@ class Surface(PtrHasData):
         return lib.wlr_surface_is_layer_surface(self._ptr)
 
     @property
+    def is_xwayland_surface(self) -> bool:
+        """
+        True if the current surface is an XWayland surface.
+
+        Requires that pywlroots was built with XWayland support.
+        """
+        return lib.wlr_surface_is_xwayland_surface(self._ptr)
+
+    @property
     def sx(self) -> int:
         """Surface local buffer x position"""
         return self._ptr.sx

--- a/wlroots/xwayland.py
+++ b/wlroots/xwayland.py
@@ -1,0 +1,455 @@
+# Copyright (c) 2022 Matt Colligan
+
+from __future__ import annotations
+
+import enum
+from typing import TYPE_CHECKING
+
+from pywayland.server import Signal
+
+from wlroots import ffi, lib, Ptr, PtrHasData, str_or_none
+from wlroots.wlr_types.surface import Surface as WlrSurface
+
+if TYPE_CHECKING:
+    from typing import TypeVar
+
+    from pywayland.server import Display
+
+    from wlroots.wlr_types import Compositor, Seat
+    from wlroots.wlr_types.xdg_shell import SurfaceCallback
+
+    T = TypeVar("T")
+
+
+class ServerOptions(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ptr
+
+    @classmethod
+    def new(
+        cls, lazy: bool, enable_wm: bool, no_touch_pointer_emulation: bool
+    ) -> ServerOptions:
+        ptr = ffi.new("struct wlr_xwayland_server_options *")
+        ptr.lazy = lazy
+        ptr.enable_wm = enable_wm
+        ptr.no_touch_pointer_emulation = no_touch_pointer_emulation
+        return cls(ptr)
+
+    @property
+    def lazy(self) -> bool:
+        return self._ptr.lazy
+
+    @lazy.setter
+    def lazy(self, lazy: bool) -> None:
+        self._ptr.lazy = lazy
+
+    @property
+    def enable_wm(self) -> bool:
+        return self._ptr.enable_wm
+
+    @enable_wm.setter
+    def enable_wm(self, enable_wm: bool) -> None:
+        self._ptr.enable_wm = enable_wm
+
+    @property
+    def no_touch_pointer_emulation(self) -> bool:
+        return self._ptr.no_touch_pointer_emulation
+
+    @no_touch_pointer_emulation.setter
+    def no_touch_pointer_emulation(self, no_touch_pointer_emulation: bool) -> None:
+        self._ptr.no_touch_pointer_emulation = no_touch_pointer_emulation
+
+
+class Server(PtrHasData):
+    def __init__(self, display: Display, options: ServerOptions) -> None:
+        ptr = lib.wlr_xwayland_server_create(display._ptr, options._ptr)
+        if ptr == ffi.NULL:
+            raise RuntimeError("Unable to create a wlr_xwayland_server.")
+
+        self._ptr = ffi.gc(ptr, lib.wlr_xwayland_server_destroy)
+
+        self.ready_event = Signal(ptr=ffi.addressof(self._ptr.events.ready))
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+
+
+class XWayland(PtrHasData):
+    def __init__(self, display: Display, compositor: Compositor, lazy: bool) -> None:
+        ptr = lib.wlr_xwayland_create(display._ptr, compositor._ptr, lazy)
+
+        if ptr == ffi.NULL:
+            raise RuntimeError("Unable to create a wlr_xwayland.")
+
+        self._ptr = ffi.gc(ptr, lib.wlr_xwayland_destroy)
+
+        self.ready_event = Signal(ptr=ffi.addressof(self._ptr.events.ready))
+        self.new_surface_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.new_surface),
+            data_wrapper=Surface,
+        )
+        self.remove_startup_info_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.remove_startup_info)
+        )
+
+    @property
+    def display_name(self) -> str | None:
+        return str_or_none(self._ptr.display_name)
+
+    def set_seat(self, seat: Seat) -> None:
+        lib.wlr_xwayland_set_seat(self._ptr, seat._ptr)
+
+    def set_cursor(
+        self,
+        pixels: list[int],
+        stride: int,
+        width: int,
+        height: int,
+        hotspot_x: int,
+        hotspot_y: int,
+    ) -> None:
+        lib.wlr_xwayland_set_cursor(
+            self._ptr, pixels, stride, width, height, hotspot_x, hotspot_y
+        )
+
+    def get_atom(self, name: str) -> int:
+        """Helper method to fetch an atom by name."""
+        conn = lib.xcb_connect(self._ptr.display_name, ffi.NULL)
+        error = lib.xcb_connection_has_error(conn)
+        if error:
+            raise RuntimeError(f"xcb_connect failed with code {error}")
+
+        name_bytes = name.encode()
+        cookie = lib.xcb_intern_atom(conn, 0, len(name_bytes), name_bytes)
+        atom = 0
+        reply = lib.xcb_intern_atom_reply(conn, cookie, ffi.NULL)
+        if reply:
+            atom = reply.atom
+        lib.xcb_disconnect(conn)
+        return atom
+
+
+class SurfaceDecorations(enum.IntEnum):
+    ALL = lib.WLR_XWAYLAND_SURFACE_DECORATIONS_ALL
+    NO_BORDER = lib.WLR_XWAYLAND_SURFACE_DECORATIONS_NO_BORDER
+    NO_TITLE = lib.WLR_XWAYLAND_SURFACE_DECORATIONS_NO_TITLE
+
+
+class ICCCMInputModel(enum.IntEnum):
+    NONE = lib.WLR_ICCCM_INPUT_MODEL_NONE
+    PASSIVE = lib.WLR_ICCCM_INPUT_MODEL_PASSIVE
+    LOCAL = lib.WLR_ICCCM_INPUT_MODEL_LOCAL
+    GLOBAL = lib.WLR_ICCCM_INPUT_MODEL_GLOBAL
+
+
+class Surface(PtrHasData):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_xwayland_surface *", ptr)
+
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+        self.request_configure_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_configure),
+            data_wrapper=SurfaceConfigureEvent,
+        )
+        self.request_move_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_move)
+        )
+        self.request_resize_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_resize)
+        )
+        self.request_minimize_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_minimize)
+        )
+        self.request_maximize_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_maximize)
+        )
+        self.request_fullscreen_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_fullscreen)
+        )
+        self.request_activate_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.request_activate)
+        )
+        self.map_event = Signal(ptr=ffi.addressof(self._ptr.events.map))
+        self.unmap_event = Signal(ptr=ffi.addressof(self._ptr.events.unmap))
+        self.set_title_event = Signal(ptr=ffi.addressof(self._ptr.events.set_title))
+        self.set_class_event = Signal(ptr=ffi.addressof(self._ptr.events.set_class))
+        self.set_role_event = Signal(ptr=ffi.addressof(self._ptr.events.set_role))
+        self.set_parent_event = Signal(ptr=ffi.addressof(self._ptr.events.set_parent))
+        self.set_pid_event = Signal(ptr=ffi.addressof(self._ptr.events.set_pid))
+        self.set_startup_id_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.set_startup_id)
+        )
+        self.set_window_type_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.set_window_type)
+        )
+        self.set_hints_event = Signal(ptr=ffi.addressof(self._ptr.events.set_hints))
+        self.set_decorations_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.set_decorations)
+        )
+        self.set_override_redirect_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.set_override_redirect)
+        )
+        self.set_geometry_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.set_geometry)
+        )
+        self.ping_timeout_event = Signal(
+            ptr=ffi.addressof(self._ptr.events.ping_timeout)
+        )
+
+    def activate(self, activated: bool) -> None:
+        lib.wlr_xwayland_surface_activate(self._ptr, activated)
+
+    def restack(self, sibling: Surface, mode: int) -> None:
+        lib.wlr_xwayland_surface_restack(self._ptr, sibling._ptr, mode)
+
+    def configure(self, x: int, y: int, width: int, height: int) -> None:
+        lib.wlr_xwayland_surface_configure(self._ptr, x, y, width, height)
+
+    def close(self) -> None:
+        lib.wlr_xwayland_surface_close(self._ptr)
+
+    def set_minimized(self, minimized: bool) -> None:
+        lib.wlr_xwayland_surface_set_minimized(self._ptr, minimized)
+
+    def set_maximized(self, maximized: bool) -> None:
+        lib.wlr_xwayland_surface_set_maximized(self._ptr, maximized)
+
+    def set_fullscreen(self, fullscreen: bool) -> None:
+        lib.wlr_xwayland_surface_set_fullscreen(self._ptr, fullscreen)
+
+    @classmethod
+    def from_wlr_surface(cls, surface: WlrSurface) -> Surface:
+        return cls(lib.wlr_xwayland_surface_from_wlr_surface(surface._ptr))
+
+    def ping(self) -> None:
+        lib.wlr_xwayland_surface_ping(self._ptr)
+
+    def or_surface_wants_focus(self) -> bool:
+        return lib.wlr_xwayland_or_surface_wants_focus(self._ptr)
+
+    def icccm_input_model(self) -> int:
+        return lib.wlr_xwayland_icccm_input_model(self._ptr)
+
+    @property
+    def surface(self) -> WlrSurface:
+        return WlrSurface(self._ptr.surface)
+
+    @property
+    def x(self) -> int:
+        return self._ptr.x
+
+    @property
+    def y(self) -> int:
+        return self._ptr.y
+
+    @property
+    def width(self) -> int:
+        return self._ptr.width
+
+    @property
+    def height(self) -> int:
+        return self._ptr.height
+
+    @property
+    def override_redirect(self) -> bool:
+        return self._ptr.override_redirect
+
+    @property
+    def mapped(self) -> bool:
+        return self._ptr.mapped
+
+    @property
+    def title(self) -> str | None:
+        return str_or_none(self._ptr.title)
+
+    @property
+    def wm_class(self) -> str | None:
+        # `self._ptr.class` is invalid syntax but this works.
+        return str_or_none(getattr(self._ptr, "class"))
+
+    @property
+    def wm_instance(self) -> str | None:
+        return str_or_none(self._ptr.wm_instance)
+
+    @property
+    def role(self) -> str | None:
+        return str_or_none(self._ptr.role)
+
+    @property
+    def startup_id(self) -> str | None:
+        return str_or_none(self._ptr.startup_id)
+
+    @property
+    def pid(self) -> int:
+        return self._ptr.pid
+
+    @property
+    def parent(self) -> Surface | None:
+        ptr = self._ptr.parent
+        if ptr == ffi.NULL:
+            return None
+        return Surface(ptr)
+
+    @property
+    def window_type(self) -> list[int]:
+        """This is an array of xcb_atom_t."""
+        if self._ptr.window_type_len == 0:
+            return []
+        return ffi.unpack(self._ptr.window_type, self._ptr.window_type_len)
+
+    @property
+    def protocols(self) -> list[int]:
+        """This is an array of xcb_atom_t."""
+        return ffi.unpack(self._ptr.protocols, self._ptr.protocols_len)
+
+    @property
+    def hints_urgency(self) -> int:
+        return self._ptr.hints_urgency
+
+    @property
+    def size_hints(self) -> SizeHints | None:
+        ptr = self._ptr.size_hints
+        if ptr == ffi.NULL:
+            return None
+        return SizeHints(ptr)
+
+    @property
+    def modal(self) -> bool:
+        return self._ptr.modal
+
+    @property
+    def fullscreen(self) -> bool:
+        return self._ptr.fullscreen
+
+    @property
+    def maximized_vert(self) -> bool:
+        return self._ptr.maximized_vert
+
+    @property
+    def maximized_horz(self) -> bool:
+        return self._ptr.maximized_horz
+
+    @property
+    def minimized(self) -> bool:
+        return self._ptr.minimized
+
+    @property
+    def has_alpha(self) -> bool:
+        return self._ptr.has_alpha
+
+    def surface_at(
+        self, surface_x: float, surface_y: float
+    ) -> tuple[WlrSurface | None, float, float]:
+        """A convenience method to match the method of WlrSurface and XdgSurface."""
+        if (
+            surface_x < 0
+            or surface_y < 0
+            or surface_x > self._ptr.width
+            or surface_y > self._ptr.height
+        ):
+            return None, 0.0, 0.0
+        return self.surface, surface_x, surface_y
+
+    def for_each_surface(
+        self, iterator: SurfaceCallback[T | None], data: T | None = None
+    ) -> None:
+        """
+        A convenience method to match the method of XdgSurface and LayerSurfaceV1.
+
+        The iterator is called using the only wlr_surface and it's local coordinates.
+        """
+        iterator(self.surface, 0, 0, data)
+
+
+class SurfaceConfigureEvent(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_xwayland_surface_configure_event *", ptr)
+
+    @property
+    def surface(self) -> Surface:
+        return Surface(self._ptr.surface)
+
+    @property
+    def x(self) -> int:
+        return self._ptr.x
+
+    @property
+    def y(self) -> int:
+        return self._ptr.y
+
+    @property
+    def width(self) -> int:
+        return self._ptr.width
+
+    @property
+    def height(self) -> int:
+        return self._ptr.height
+
+    @property
+    def mask(self) -> int:
+        return self._ptr.mask
+
+
+class ResizeEvent(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_xwayland_resize_event *", ptr)
+
+    @property
+    def surface(self) -> Surface:
+        return Surface(self._ptr.surface)
+
+    @property
+    def edges(self) -> int:
+        return self._ptr.edges
+
+
+class MinimizeEvent(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_xwayland_minimize_event *", ptr)
+
+    @property
+    def surface(self) -> Surface:
+        return Surface(self._ptr.surface)
+
+    @property
+    def minimize(self) -> bool:
+        return self._ptr.minimize
+
+
+class SizeHints(Ptr):
+    def __init__(self, ptr) -> None:
+        self._ptr = ffi.cast("struct wlr_xwayland_surface_size_hints *", ptr)
+
+    @property
+    def flags(self) -> int:
+        return self._ptr.flags
+
+    @property
+    def x(self) -> int:
+        return self._ptr.x
+
+    @property
+    def y(self) -> int:
+        return self._ptr.y
+
+    @property
+    def width(self) -> int:
+        return self._ptr.width
+
+    @property
+    def height(self) -> int:
+        return self._ptr.height
+
+    @property
+    def min_width(self) -> int:
+        return self._ptr.min_width
+
+    @property
+    def min_height(self) -> int:
+        return self._ptr.min_height
+
+    @property
+    def max_width(self) -> int:
+        return self._ptr.max_width
+
+    @property
+    def max_height(self) -> int:
+        return self._ptr.max_height


### PR DESCRIPTION
I'm playing around with XWayland, with the first step getting the C code compiled into the cffi. Unfortunately I've only got so far, so I am posting to see if you would have any ideas of how to fix the compilation errors.

There are a few `typedef`s that I've had to add, which I suspect are responsible. The full traceback I'm getting while building is:
```
Traceback (most recent call last):
  File "/home/mcol/git/pywlroots/wlroots/ffi_build.py", line 2480, in <module>
    ffi_builder.cdef(CDEF)
  File "/usr/lib/python3.10/site-packages/cffi/api.py", line 112, in cdef
    self._cdef(csource, override=override, packed=packed, pack=pack)
  File "/usr/lib/python3.10/site-packages/cffi/api.py", line 126, in _cdef
    self._parser.parse(csource, override=override, **options)
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 389, in parse
    self._internal_parse(csource)
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 428, in _internal_parse
    realtype, quals = self._get_type_and_quals(
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 674, in _get_type_and_quals
    tp = self._get_struct_union_enum_type('struct', type, name)
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 797, in _get_struct_union_enum_type
    self._declare(key, tp)
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 571, in _declare
    assert '__dotdotdot__' not in name.split()
AssertionError
```

Any thoughts?