### PR TITLE
Get build-time information from local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.so
 *.o
 *.c
+_build.py
 
 # Test output
 .coverage


### PR DESCRIPTION
This updates the build step such that the wlroots version is fetched
from the compiled `lib` if it cannot be fetched from the system via
`ffi.verify`.

Similarly XWayland support is fetched from a local `_build.py` if it
cannot be determined with `ffi.verify`, which is generated during a
successful build.

Closes #77