### PR TITLE
Don't wrap IdleInhibitorV1's destroy event data

### DIFF
--- a/wlroots/wlr_types/idle_inhibit_v1.py
+++ b/wlroots/wlr_types/idle_inhibit_v1.py
@@ -21,9 +21,7 @@ class IdleInhibitorV1(PtrHasData):
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_idle_inhibitor_v1 *", ptr)
 
-        self.destroy_event = Signal(
-            ptr=ffi.addressof(self._ptr.events.destroy), data_wrapper=Surface
-        )
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
     @property
     def surface(self) -> Surface:


### PR DESCRIPTION
According to wlroots' emitter for this signal, it *does* return the idle
inhibitor's `struct wlr_surface*`. However, in practice the pointed-to
data seems to be invalid, causing a crash (e.g.
https://github.com/qtile/qtile/issues/3361).

The data does not seem to be used by any compositor so until it is
needed we can probably get away without the wrapper, resolving the
problem.