### PR TITLE
Catch OSErrors triggered by ffi_build.py version check

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -36,7 +36,7 @@ def load_wlroots_version():
 
     try:
         lib = ffi.verify("#include <wlr/version.h>")
-    except PermissionError:
+    except (PermissionError, OSError):
         lib = importlib.import_module("wlroots").lib
 
     return f"{lib.WLR_VERSION_MAJOR}.{lib.WLR_VERSION_MINOR}.{lib.WLR_VERSION_MICRO}"


### PR DESCRIPTION
On read-only file systems, `ffi.verify` fails:
```
OSError: [Errno 30] Read-only file system
```

This should catch that case in a similar fashion to PermissionError.