### PR TITLE
XWayland surface restack sibling is optional

### DIFF
--- a/wlroots/xwayland.py
+++ b/wlroots/xwayland.py
@@ -202,8 +202,11 @@ class Surface(PtrHasData):
     def activate(self, activated: bool) -> None:
         lib.wlr_xwayland_surface_activate(self._ptr, activated)
 
-    def restack(self, sibling: Surface, mode: int) -> None:
-        lib.wlr_xwayland_surface_restack(self._ptr, sibling._ptr, mode)
+    def restack(self, sibling: Surface | None, mode: int) -> None:
+        if sibling:
+            lib.wlr_xwayland_surface_restack(self._ptr, sibling._ptr, mode)
+        else:
+            lib.wlr_xwayland_surface_restack(self._ptr, ffi.NULL, mode)
 
     def configure(self, x: int, y: int, width: int, height: int) -> None:
         lib.wlr_xwayland_surface_configure(self._ptr, x, y, width, height)


### PR DESCRIPTION
Restacking an XWayland surface does not require a sibling, and instead
it can be a null pointer, causing the window to restack to the top or
bottom of all windows.