### PR TITLE
Expose xcursors to enable setting xwayland cursor images

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -1871,6 +1871,26 @@ int wlr_xcursor_manager_load(struct wlr_xcursor_manager *manager,
     float scale);
 void wlr_xcursor_manager_set_cursor_image(struct wlr_xcursor_manager *manager,
     const char *name, struct wlr_cursor *cursor);
+struct wlr_xcursor *wlr_xcursor_manager_get_xcursor(
+    struct wlr_xcursor_manager *manager, const char *name, float scale);
+"""
+
+# xcursor.h
+CDEF += """
+struct wlr_xcursor_image {
+    uint32_t width;
+    uint32_t height;
+    uint32_t hotspot_x;
+    uint32_t hotspot_y;
+    uint32_t delay;
+    uint8_t *buffer;
+};
+struct wlr_xcursor {
+    unsigned int image_count;
+    struct wlr_xcursor_image **images;
+    char *name;
+    uint32_t total_delay;
+};
 """
 
 # types/wlr_xdg_decoration_v1.h

--- a/wlroots/wlr_types/xcursor_manager.py
+++ b/wlroots/wlr_types/xcursor_manager.py
@@ -1,8 +1,15 @@
 # Copyright (c) Sean Vig 2019
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from wlroots import ffi, lib, Ptr
 
 from .cursor import Cursor
+
+if TYPE_CHECKING:
+    from typing import Iterator
 
 
 class XCursorManager(Ptr):
@@ -33,6 +40,17 @@ class XCursorManager(Ptr):
         name_cdata = ffi.new("char []", name.encode())
         lib.wlr_xcursor_manager_set_cursor_image(self._ptr, name_cdata, cursor._ptr)
 
+    def get_xcursor(self, name: str, scale: float = 1) -> XCursor | None:
+        """
+        Retrieves a wlr_xcursor reference for the given cursor name at the given scale
+        factor, or NULL if this wlr_xcursor_manager has not loaded a cursor theme at the
+        requested scale.
+        """
+        ptr = lib.wlr_xcursor_manager_get_xcursor(self._ptr, name.encode(), scale)
+        if ptr == ffi.NULL:
+            return None
+        return XCursor(ptr)
+
     def __enter__(self):
         """Setup X cursor manager in a context manager"""
         return self
@@ -40,3 +58,22 @@ class XCursorManager(Ptr):
     def __exit__(self, exc_type, exc_value, exc_tb):
         """Clean-up the X cursor manager on contex manager exit"""
         self.destroy()
+
+
+class XCursor(Ptr):
+    """struct wlr_xcursor"""
+
+    def __init__(self, ptr):
+        self._ptr = ptr
+
+    @property
+    def images(self) -> Iterator[XCursorImage]:
+        for i in range(self._ptr.image_count):
+            yield XCursorImage(self._ptr.images[0][i])
+
+
+class XCursorImage(Ptr):
+    """struct wlr_xcursor_image"""
+
+    def __init__(self, ptr):
+        self._ptr = ptr


### PR DESCRIPTION
This adds the structs wlr_xcursor and wlr_xcursor_image, which lets a
compositor get an xcursor from the xcursor_manager and use it e.g. to
configure xwayland's default cursor image.