### PR TITLE
[update] improve SIGINT handler

### DIFF
--- a/tiny/__main__.py
+++ b/tiny/__main__.py
@@ -6,13 +6,11 @@ bindings (`python wlroots/ffi_build.py`), and launch the main (`python -m tiny`)
 from __future__ import annotations
 
 import logging
-import signal
 import sys
-from functools import partial
 
 from pywayland.server import Display
-
 from wlroots.helper import build_compositor
+from wlroots.util.log import log_init
 from wlroots.wlr_types import (
     Cursor,
     DataDeviceManager,
@@ -22,20 +20,12 @@ from wlroots.wlr_types import (
     XCursorManager,
     XdgShell,
 )
-from wlroots.util.log import log_init
 
 from .server import TinywlServer
 
 
-def sig_cb(display, sig_num, frame):
-    print("shutdown on terminate")
-    display.terminate()
-
-
 def main(argv) -> None:
     with Display() as display:
-        signal.signal(signal.SIGINT, partial(sig_cb, display))
-
         compositor, allocator, renderer, backend = build_compositor(display)
         device_manager = DataDeviceManager(display)  # noqa: F841
         xdg_shell = XdgShell(display)

--- a/tiny/keyboard_handler.py
+++ b/tiny/keyboard_handler.py
@@ -7,6 +7,7 @@ from pywayland.server import Listener
 if TYPE_CHECKING:
     from wlroots.wlr_types import InputDevice, Keyboard
     from wlroots.wlr_types.keyboard import KeyboardKeyEvent
+
     from .server import TinywlServer
 
 

--- a/tiny/view.py
+++ b/tiny/view.py
@@ -4,14 +4,15 @@ import logging
 from typing import TYPE_CHECKING
 
 from pywayland.server import Listener
-
 from wlroots.util.box import Box
 from wlroots.util.edges import Edges
+
 from .cursor_mode import CursorMode
 
 if TYPE_CHECKING:
     from wlroots.wlr_types import SceneNode, Surface
     from wlroots.wlr_types.xdg_shell import XdgSurface
+
     from .server import TinywlServer
 
 


### PR DESCRIPTION
* Current signal implementation often does not work unless the frame
  is focused. It also does not work if the frame is closed before the
  SIGINT signal is sent.

* This commit uses the wayland event loop to incorporate the signal
  handling directly in the compositor event loop.

Signed-off-by: Shinyzenith <aakashsensharma@gmail.com>