### PR TITLE
Correct 2 enums to be IntFlags, supporting 0s

### DIFF
--- a/wlroots/wlr_types/foreign_toplevel_management_v1.py
+++ b/wlroots/wlr_types/foreign_toplevel_management_v1.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 _weakkeydict: WeakKeyDictionary = WeakKeyDictionary()
 
 
-class ForeignToplevelHandleV1State(enum.IntEnum):
+class ForeignToplevelHandleV1State(enum.IntFlag):
     MAXIMIZED = 1 << 0
     MINIMIZED = 1 << 1
     ACTIVATED = 1 << 2

--- a/wlroots/wlr_types/pointer_constraints_v1.py
+++ b/wlroots/wlr_types/pointer_constraints_v1.py
@@ -23,7 +23,7 @@ class PointerConstraintV1Type(enum.IntEnum):
     CONFINED = lib.WLR_POINTER_CONSTRAINT_V1_CONFINED
 
 
-class PointerConstraintV1StateField(enum.IntEnum):
+class PointerConstraintV1StateField(enum.IntFlag):
     REGION = lib.WLR_POINTER_CONSTRAINT_V1_STATE_REGION
     CURSOR_HINT = lib.WLR_POINTER_CONSTRAINT_V1_STATE_CURSOR_HINT
 


### PR DESCRIPTION
These two wlroots enums are intended to be used as bit flags, supporting
0 or bitwise combinations of their values. Their current `IntEnum` base
class doesn't support either so let's convert to `IntFlag`.