### PR TITLE
Fix up some output code

### DIFF
--- a/tiny/server.py
+++ b/tiny/server.py
@@ -308,14 +308,9 @@ class TinywlServer:
     def server_new_output(self, listener, output: Output) -> None:
         output.init_render(self._allocator, self._renderer)
 
-        if output.modes != []:
-            mode = output.preferred_mode()
-            if mode is None:
-                logger.error("Got no output mode")
-                return
-            output.set_mode(mode)
-            output.enable()
-            output.commit()
+        output.set_mode(output.preferred_mode())
+        output.enable()
+        output.commit()
 
         self.outputs.append(output)
         self._output_layout.add_auto(output)

--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -853,6 +853,14 @@ bool pixman_region32_not_empty(struct pixman_region32 *region);
 
 # types/wlr_output.h
 CDEF += """
+struct wlr_output_mode {
+    int32_t width, height;
+    int32_t refresh; // mHz
+    bool preferred;
+    struct wl_list link;
+    ...;
+};
+
 struct wlr_output_state {
     ...;
 };

--- a/wlroots/wlr_types/output_layout.py
+++ b/wlroots/wlr_types/output_layout.py
@@ -89,7 +89,7 @@ class OutputLayout(Ptr):
         """Remove an output from the layout."""
         lib.wlr_output_layout_remove(self._ptr, output._ptr)
 
-    def get_box(self, reference: Output | None = None) -> Box:
+    def get_box(self, reference: Output | None = None) -> Box | None:
         """
         Get the box of the layout for the given reference output in layout
         coordinates. If `reference` is None, the box will be for the extents of the
@@ -97,6 +97,8 @@ class OutputLayout(Ptr):
         """
         if reference:
             box_ptr = lib.wlr_output_layout_get_box(self._ptr, reference._ptr)
+            if box_ptr == ffi.NULL:
+                return None
         else:
             box_ptr = lib.wlr_output_layout_get_box(self._ptr, ffi.NULL)
         return Box(ptr=box_ptr)

--- a/wlroots/wlr_types/output_management_v1.py
+++ b/wlroots/wlr_types/output_management_v1.py
@@ -63,12 +63,17 @@ class OutputHeadV1State(Ptr):
         return Output(self._ptr.output)
 
     @property
-    def mode(self) -> OutputMode:
+    def mode(self) -> OutputMode | None:
+        if self._ptr.mode == ffi.NULL:
+            return None
         return OutputMode(self._ptr.mode)
 
     @mode.setter
-    def mode(self, value: OutputMode) -> None:
-        self._ptr.mode = value._ptr
+    def mode(self, mode: OutputMode | None) -> None:
+        if mode is None:
+            self._ptr.mode = ffi.NULL
+        else:
+            self._ptr.mode = mode._ptr
 
     @property
     def custom_mode(self):


### PR DESCRIPTION
Properly adds `struct wlr_output_mode` and lets users iterate through
them from `Output`. Fixes the typing for a number of output-related
methods which may accept/return `NULL`s, so their types should reflect
that (`x | None`).