### PR TITLE
Add wlr_xdg_surface_schedule_configure as XdgSurface method

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -2334,6 +2334,8 @@ void wlr_xdg_surface_for_each_surface(struct wlr_xdg_surface *surface,
 
 void wlr_xdg_surface_for_each_popup_surface(struct wlr_xdg_surface *surface,
     wlr_surface_iterator_func_t iterator, void *user_data);
+
+uint32_t wlr_xdg_surface_schedule_configure(struct wlr_xdg_surface *surface);
 """
 
 # util/edges.h

--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -196,6 +196,13 @@ class XdgSurface(PtrHasData):
             self._ptr, lib.surface_iterator_callback, handle
         )
 
+    def schedule_configure(self) -> int:
+        """
+        Schedule a surface configuration. This should only be called by protocols
+        extending the shell.
+        """
+        return lib.wlr_xdg_surface_schedule_configure(self._ptr)
+
 
 class XdgSurfaceConfigure(Ptr):
     def __init__(self, ptr) -> None:


### PR DESCRIPTION
This exposes the wlroots `wlr_xdg_surface_schedule_configure` method.