### PR TITLE
Add handlers for wlr_pointer_gestures_v1

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -1282,6 +1282,19 @@ struct wlr_event_pointer_pinch_end {
     bool cancelled;
     ...;
 };
+
+struct wlr_event_pointer_hold_begin {
+    struct wlr_input_device *device;
+    uint32_t time_msec;
+    uint32_t fingers;
+    ...;
+};
+struct wlr_event_pointer_hold_end {
+    struct wlr_input_device *device;
+    uint32_t time_msec;
+    bool cancelled;
+    ...;
+};
 """
 
 # types/wlr_pointer_constraints_v1.h
@@ -1358,6 +1371,75 @@ void wlr_pointer_constraint_v1_send_activated(
     struct wlr_pointer_constraint_v1 *constraint);
 void wlr_pointer_constraint_v1_send_deactivated(
     struct wlr_pointer_constraint_v1 *constraint);
+"""
+
+# types/wlr_pointer_gestures_v1.h
+CDEF += """
+struct wlr_pointer_gestures_v1 {
+    struct wl_global *global;
+    struct wl_list swipes;
+    struct wl_list pinches;
+    struct wl_list holds;
+
+    struct wl_listener display_destroy;
+
+    struct {
+        struct wl_signal destroy;
+    } events;
+
+    void *data;
+    ...;
+};
+
+struct wlr_pointer_gestures_v1 *wlr_pointer_gestures_v1_create(
+    struct wl_display *display);
+
+void wlr_pointer_gestures_v1_send_swipe_begin(
+    struct wlr_pointer_gestures_v1 *gestures,
+    struct wlr_seat *seat,
+    uint32_t time_msec,
+    uint32_t fingers);
+void wlr_pointer_gestures_v1_send_swipe_update(
+    struct wlr_pointer_gestures_v1 *gestures,
+    struct wlr_seat *seat,
+    uint32_t time_msec,
+    double dx,
+    double dy);
+void wlr_pointer_gestures_v1_send_swipe_end(
+    struct wlr_pointer_gestures_v1 *gestures,
+    struct wlr_seat *seat,
+    uint32_t time_msec,
+    bool cancelled);
+
+void wlr_pointer_gestures_v1_send_pinch_begin(
+    struct wlr_pointer_gestures_v1 *gestures,
+    struct wlr_seat *seat,
+    uint32_t time_msec,
+    uint32_t fingers);
+void wlr_pointer_gestures_v1_send_pinch_update(
+    struct wlr_pointer_gestures_v1 *gestures,
+    struct wlr_seat *seat,
+    uint32_t time_msec,
+    double dx,
+    double dy,
+    double scale,
+    double rotation);
+void wlr_pointer_gestures_v1_send_pinch_end(
+    struct wlr_pointer_gestures_v1 *gestures,
+    struct wlr_seat *seat,
+    uint32_t time_msec,
+    bool cancelled);
+
+void wlr_pointer_gestures_v1_send_hold_begin(
+    struct wlr_pointer_gestures_v1 *gestures,
+    struct wlr_seat *seat,
+    uint32_t time_msec,
+    uint32_t fingers);
+void wlr_pointer_gestures_v1_send_hold_end(
+    struct wlr_pointer_gestures_v1 *gestures,
+    struct wlr_seat *seat,
+    uint32_t time_msec,
+    bool cancelled);
 """
 
 # types/wlr_primary_selection_v1.h
@@ -2431,6 +2513,7 @@ SOURCE = """
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_output_power_management_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
+#include <wlr/types/wlr_pointer_gestures_v1.h>
 #include <wlr/types/wlr_primary_selection.h>
 #include <wlr/types/wlr_primary_selection_v1.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>

--- a/wlroots/wlr_types/__init__.py
+++ b/wlroots/wlr_types/__init__.py
@@ -26,6 +26,7 @@ from .pointer_constraints_v1 import (  # noqa: F401
     PointerConstraintsV1,
     PointerConstraintV1,
 )
+from .pointer_gestures_v1 import PointerGesturesV1  # noqa: F401
 from .primary_selection_v1 import PrimarySelectionV1DeviceManager  # noqa: F401
 from .relative_pointer_manager_v1 import RelativePointerManagerV1  # noqa: F401
 from .scene import Scene, SceneNode  # noqa: F401

--- a/wlroots/wlr_types/cursor.py
+++ b/wlroots/wlr_types/cursor.py
@@ -19,6 +19,8 @@ from .pointer import (
     PointerEventSwipeBegin,
     PointerEventSwipeEnd,
     PointerEventSwipeUpdate,
+    PointerEventHoldBegin,
+    PointerEventHoldEnd,
 )
 from .surface import Surface
 from .touch import (
@@ -88,6 +90,14 @@ class Cursor(PtrHasData):
         self.pinch_end = Signal(
             ptr=ffi.addressof(self._ptr.events.pinch_end),
             data_wrapper=PointerEventPinchEnd,
+        )
+        self.hold_begin = Signal(
+            ptr=ffi.addressof(self._ptr.events.hold_begin),
+            data_wrapper=PointerEventHoldBegin,
+        )
+        self.hold_end = Signal(
+            ptr=ffi.addressof(self._ptr.events.hold_end),
+            data_wrapper=PointerEventHoldEnd,
         )
 
         self.touch_up_event = Signal(

--- a/wlroots/wlr_types/pointer.py
+++ b/wlroots/wlr_types/pointer.py
@@ -151,11 +151,35 @@ class PointerEventSwipeBegin(Ptr):
         ptr = ffi.cast("struct wlr_event_pointer_swipe_begin *", ptr)
         self._ptr = ptr
 
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def fingers(self) -> int:
+        return self._ptr.fingers
+
 
 class PointerEventSwipeUpdate(Ptr):
     def __init__(self, ptr) -> None:
         ptr = ffi.cast("struct wlr_event_pointer_swipe_update *", ptr)
         self._ptr = ptr
+
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def fingers(self) -> int:
+        return self._ptr.fingers
+
+    @property
+    def dx(self) -> float:
+        return self._ptr.dx
+
+    @property
+    def dy(self) -> float:
+        return self._ptr.dy
 
 
 class PointerEventSwipeEnd(Ptr):
@@ -163,11 +187,27 @@ class PointerEventSwipeEnd(Ptr):
         ptr = ffi.cast("struct wlr_event_pointer_swipe_end *", ptr)
         self._ptr = ptr
 
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def cancelled(self) -> bool:
+        return self._ptr.cancelled
+
 
 class PointerEventPinchBegin(Ptr):
     def __init__(self, ptr) -> None:
         ptr = ffi.cast("struct wlr_event_pointer_pinch_begin *", ptr)
         self._ptr = ptr
+
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def fingers(self) -> int:
+        return self._ptr.fingers
 
 
 class PointerEventPinchUpdate(Ptr):
@@ -175,8 +215,68 @@ class PointerEventPinchUpdate(Ptr):
         ptr = ffi.cast("struct wlr_event_pointer_pinch_update *", ptr)
         self._ptr = ptr
 
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def fingers(self) -> int:
+        return self._ptr.fingers
+
+    @property
+    def dx(self) -> float:
+        return self._ptr.dx
+
+    @property
+    def dy(self) -> float:
+        return self._ptr.dy
+
+    @property
+    def scale(self) -> float:
+        return self._ptr.scale
+
+    @property
+    def rotation(self) -> float:
+        return self._ptr.rotation
+
 
 class PointerEventPinchEnd(Ptr):
     def __init__(self, ptr) -> None:
         ptr = ffi.cast("struct wlr_event_pointer_pinch_end *", ptr)
         self._ptr = ptr
+
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def cancelled(self) -> bool:
+        return self._ptr.cancelled
+
+
+class PointerEventHoldBegin(Ptr):
+    def __init__(self, ptr) -> None:
+        ptr = ffi.cast("struct wlr_event_pointer_hold_begin *", ptr)
+        self._ptr = ptr
+
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def fingers(self) -> int:
+        return self._ptr.fingers
+
+
+class PointerEventHoldEnd(Ptr):
+    def __init__(self, ptr) -> None:
+        ptr = ffi.cast("struct wlr_event_pointer_hold_end *", ptr)
+        self._ptr = ptr
+
+    @property
+    def time_msec(self) -> int:
+        return self._ptr.time_msec
+
+    @property
+    def cancelled(self) -> bool:
+        return self._ptr.cancelled

--- a/wlroots/wlr_types/pointer_gestures_v1.py
+++ b/wlroots/wlr_types/pointer_gestures_v1.py
@@ -1,0 +1,104 @@
+# Copyright (c) Matt Colligan 2022
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pywayland.server import Signal
+
+from wlroots import ffi, lib, PtrHasData
+
+if TYPE_CHECKING:
+    from pywayland.server import Display
+
+    from .seat import Seat
+
+
+class PointerGesturesV1(PtrHasData):
+    def __init__(self, display: Display) -> None:
+        """Manager to relay pointer gestures to clients.
+
+        :param display:
+            The display to relay gestures for.
+        """
+        self._ptr = lib.wlr_pointer_gestures_v1_create(display._ptr)
+
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
+
+    def send_swipe_begin(self, seat: Seat, time_msec: int, fingers: int) -> None:
+        lib.wlr_pointer_gestures_v1_send_swipe_begin(
+            self._ptr,
+            seat._ptr,
+            time_msec,
+            fingers,
+        )
+
+    def send_swipe_update(
+        self, seat: Seat, time_msec: int, dx: float, dy: float
+    ) -> None:
+        lib.wlr_pointer_gestures_v1_send_swipe_update(
+            self._ptr,
+            seat._ptr,
+            time_msec,
+            dx,
+            dy,
+        )
+
+    def send_swipe_end(self, seat: Seat, time_msec: int, cancelled: bool) -> None:
+        lib.wlr_pointer_gestures_v1_send_swipe_end(
+            self._ptr,
+            seat._ptr,
+            time_msec,
+            cancelled,
+        )
+
+    def send_pinch_begin(self, seat: Seat, time_msec: int, fingers: int) -> None:
+        lib.wlr_pointer_gestures_v1_send_pinch_begin(
+            self._ptr,
+            seat._ptr,
+            time_msec,
+            fingers,
+        )
+
+    def send_pinch_update(
+        self,
+        seat: Seat,
+        time_msec: int,
+        dx: float,
+        dy: float,
+        scale: float,
+        rotation: float,
+    ) -> None:
+        lib.wlr_pointer_gestures_v1_send_pinch_update(
+            self._ptr,
+            seat._ptr,
+            time_msec,
+            dx,
+            dy,
+            scale,
+            rotation,
+        )
+
+    def send_pinch_end(self, seat: Seat, time_msec: int, cancelled: bool) -> None:
+        lib.wlr_pointer_gestures_v1_send_pinch_end(
+            self._ptr,
+            seat._ptr,
+            time_msec,
+            cancelled,
+        )
+
+    def send_hold_begin(self, seat: Seat, time_msec: int, fingers: int) -> None:
+        lib.wlr_pointer_gestures_v1_send_hold_begin(
+            self._ptr,
+            seat._ptr,
+            time_msec,
+            fingers,
+        )
+
+    def send_hold_end(self, seat: Seat, time_msec: int, cancelled: bool) -> None:
+        lib.wlr_pointer_gestures_v1_send_hold_end(
+            self._ptr,
+            seat._ptr,
+            time_msec,
+            cancelled,
+        )


### PR DESCRIPTION
This lets compositors relay multi-finger touchpad events to clients. Similarly event classes in pointer.py are given getters to provide data from those events which are used by PointerGesturesV1.