### PR TITLE
Drag.icon can also return None if clients don't provide icons to render

### DIFF
--- a/wlroots/wlr_types/data_device_manager.py
+++ b/wlroots/wlr_types/data_device_manager.py
@@ -37,8 +37,10 @@ class Drag(Ptr):
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
     @property
-    def icon(self) -> "DragIcon":
+    def icon(self) -> "DragIcon | None":
         icon_ptr = self._ptr.icon
+        if icon_ptr == ffi.NULL:
+            return None
         _weakkeydict[icon_ptr] = self._ptr
         return DragIcon(icon_ptr)
 


### PR DESCRIPTION
Drags provided by clients might not provide icons for rendering (e.g. google chrome), so trying to create Icons for ffi.NULL causes segfaults.

E.g. see https://github.com/qtile/qtile/issues/3894