### PR TITLE
Enable xwayland feature for wlroots build step when making a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Build wlroots
         working-directory: wlroots-${{ env.wlroots-version }}
         run: |
-          meson build --prefix=/usr
+          meson build --prefix=/usr -Dxwayland=enabled
           ninja -C build
           DESTDIR=~/wayland ninja -C build install
       - name: Create artifact


### PR DESCRIPTION
This is already set in the ci.yaml, but not in release.yaml. It needs to be set because its false by default in wlroots.

Closes #112





I *think* this should work, but I'm not certain. Is there a way to do test releases to pypi?