### PR TITLE
Minor keyboard handling improvements

### DIFF
--- a/tiny/server.py
+++ b/tiny/server.py
@@ -300,7 +300,8 @@ class TinywlServer:
         # keep track of this and automatically send key events to the
         # appropriate clients without additional work on your part.
         keyboard = self._seat.keyboard
-        self._seat.keyboard_notify_enter(view.xdg_surface.surface, keyboard)
+        if keyboard:
+            self._seat.keyboard_notify_enter(view.xdg_surface.surface, keyboard)
 
     # #############################################################
     # surface handling callbacks

--- a/wlroots/wlr_types/keyboard.py
+++ b/wlroots/wlr_types/keyboard.py
@@ -128,13 +128,10 @@ class Keyboard(PtrHasData):
     @property
     def modifier(self) -> KeyboardModifier:
         """The enum representing the currently active modifier keys"""
+        if self._ptr == ffi.NULL:
+            raise RuntimeError("Tried to get modifier for NULL keyboard.")
         modifiers = lib.wlr_keyboard_get_modifiers(self._ptr)
         return KeyboardModifier(modifiers)
-
-    @property
-    def destroyed(self) -> bool:
-        """Tells you whether or not this keyboard has been destroyed"""
-        return self._ptr == ffi.NULL
 
 
 class KeyboardModifiers(Ptr):

--- a/wlroots/wlr_types/seat.py
+++ b/wlroots/wlr_types/seat.py
@@ -115,9 +115,11 @@ class Seat(PtrHasData):
         return SeatKeyboardState(keyboard_state_ptr)
 
     @property
-    def keyboard(self) -> Keyboard:
-        """Get the keyboard associated with this seat"""
+    def keyboard(self) -> Keyboard | None:
+        """Get the active keyboard for the seat."""
         keyboard_ptr = lib.wlr_seat_get_keyboard(self._ptr)
+        if keyboard_ptr == ffi.NULL:
+            return None
         return Keyboard(keyboard_ptr)
 
     def destroy(self) -> None:


### PR DESCRIPTION
- Check whether a keyboard is NULL before accessing its modifier state, to avoid a compositor crash
- drop the `keyboard.destroyed` property. It doesn't work if you have as the pointer being NULL is not the same as the wlr_keyboard being destroyed.
- make the return type of `seat.keyboard` `Keyboard | NULL` as a seat might not have an active keyboard.