### PR TITLE
Expose `wlr_keyboard_notify_modifiers` function.

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -1005,6 +1005,13 @@ struct wlr_keyboard *wlr_keyboard_from_input_device(
     struct wlr_input_device *input_device);
 """
 
+# wlr/interfaces/wlr_keyboard.h
+CDEF += """
+void wlr_keyboard_notify_modifiers(struct wlr_keyboard *keyboard,
+    uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
+    uint32_t group);
+"""
+
 # types/wlr_linux_dmabuf_v1.h
 CDEF += """
 struct wlr_linux_dmabuf_v1 *wlr_linux_dmabuf_v1_create(struct wl_display *display,

--- a/wlroots/wlr_types/keyboard.py
+++ b/wlroots/wlr_types/keyboard.py
@@ -33,7 +33,7 @@ class KeyboardModifier(enum.IntFlag):
     MOD5 = lib.WLR_MODIFIER_MOD5
 
 
-class ModifiersMask():
+class ModifiersMask:
     def __init__(self) -> None:
         """The modifiers mask"""
         self._mask = ffi.new("xkb_mod_mask_t *", 0)
@@ -44,7 +44,9 @@ class ModifiersMask():
         Numlock is Mod2 and Capslock is Lock
         """
         idx = ffi.new("xkb_mod_index_t *")
-        idx[0] = lib.xkb_keymap_mod_get_index(keyboard._ptr.keymap, ffi.new("const char []", modifier.encode("ascii")))
+        idx[0] = lib.xkb_keymap_mod_get_index(
+            keyboard._ptr.keymap, ffi.new("const char []", modifier.encode("ascii"))
+        )
         self._mask[0] |= self._one[0] << idx[0]
 
 
@@ -126,7 +128,9 @@ class Keyboard(PtrHasData):
     def notify_modifiers(self, mask: ModifiersMask) -> None:
         """Notify the keyboard that modifiers have been updated"""
         zero = ffi.new("uint32_t *", 0)
-        lib.wlr_keyboard_notify_modifiers(self._ptr, zero[0], zero[0], mask._mask[0], zero[0])
+        lib.wlr_keyboard_notify_modifiers(
+            self._ptr, zero[0], zero[0], mask._mask[0], zero[0]
+        )
 
     @property
     def keycodes(self):

--- a/wlroots/wlr_types/keyboard.py
+++ b/wlroots/wlr_types/keyboard.py
@@ -33,6 +33,21 @@ class KeyboardModifier(enum.IntFlag):
     MOD5 = lib.WLR_MODIFIER_MOD5
 
 
+class ModifiersMask():
+    def __init__(self) -> None:
+        """The modifiers mask"""
+        self._mask = ffi.new("xkb_mod_mask_t *", 0)
+        self._one = ffi.new("uint32_t *", 1)
+
+    def add(self, modifier: str, keyboard: Keyboard) -> None:
+        """Add a modifier to the mask
+        Numlock is Mod2 and Capslock is Lock
+        """
+        idx = ffi.new("xkb_mod_index_t *")
+        idx[0] = lib.xkb_keymap_mod_get_index(keyboard._ptr.keymap, ffi.new("const char []", modifier.encode("ascii")))
+        self._mask[0] |= self._one[0] << idx[0]
+
+
 class KeyboardKeyEvent(Ptr):
     def __init__(self, ptr) -> None:
         """Event that a key has been pressed or release
@@ -107,6 +122,11 @@ class Keyboard(PtrHasData):
             The delay in milliseconds before repeating
         """
         lib.wlr_keyboard_set_repeat_info(self._ptr, rate, delay)
+
+    def notify_modifiers(self, mask: ModifiersMask) -> None:
+        """Notify the keyboard that modifiers have been updated"""
+        zero = ffi.new("uint32_t *", 0)
+        lib.wlr_keyboard_notify_modifiers(self._ptr, zero[0], zero[0], mask._mask[0], zero[0])
 
     @property
     def keycodes(self):

--- a/wlroots/wlr_types/keyboard.py
+++ b/wlroots/wlr_types/keyboard.py
@@ -34,18 +34,20 @@ class KeyboardModifier(enum.IntFlag):
 
 
 class ModifiersMask:
-    def __init__(self) -> None:
+    def __init__(self, keyboard: Keyboard) -> None:
         """The modifiers mask"""
         self._mask = ffi.new("xkb_mod_mask_t *", 0)
         self._one = ffi.new("uint32_t *", 1)
+        self._keyboard = keyboard
 
-    def add(self, modifier: str, keyboard: Keyboard) -> None:
+    def add(self, modifier: str) -> None:
         """Add a modifier to the mask
         Numlock is Mod2 and Capslock is Lock
         """
         idx = ffi.new("xkb_mod_index_t *")
         idx[0] = lib.xkb_keymap_mod_get_index(
-            keyboard._ptr.keymap, ffi.new("const char []", modifier.encode("ascii"))
+            self._keyboard._ptr.keymap,
+            ffi.new("const char []", modifier.encode("ascii")),
         )
         self._mask[0] |= self._one[0] << idx[0]
 


### PR DESCRIPTION
[Sway](https://github.com/swaywm/sway/pull/2330) uses this function to configure the initial state of numlock/capslock.

Tested with Qtile.

Compositors would implement something similar to sway, like this to enable Numlock:

```py
mask = ffi.new("xkb_mod_mask_t *", 0)
one = ffi.new("uint32_t *", 1)
idx = ffi.new("xkb_mod_index_t *")
idx[0] = lib.xkb_keymap_mod_get_index(self.keyboard._ptr.keymap, ffi.new("const char []", "Mod2".encode("ascii")))
mask[0] |= one[0] << idx[0]
zero = ffi.new("uint32_t *", 0)           
lib.wlr_keyboard_notify_modifiers(self.keyboard._ptr, zero[0], zero[0], mask[0], zero[0])
``` 

the Capslock is named `Lock`.
My implementation is definitely not the best but it works.

I'm not sure if there's a way to do the same thing using pywlroots instead of copying sway's implementation.