### PR TITLE
Add missing include

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -2779,6 +2779,7 @@ SOURCE = """
 #include <wlr/backend.h>
 #include <wlr/backend/headless.h>
 #include <wlr/backend/libinput.h>
+#include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/render/allocator.h>
 #include <wlr/render/drm_format_set.h>
 #include <wlr/render/wlr_renderer.h>


### PR DESCRIPTION
Got following error when compiling with clang:

> /var/tmp/portage/dev-python/pywlroots-0.16.5/work/pywlroots-0.16.5-python3_11/build/temp.linux-x86_64-cpython-311/wlroots._ffi.c:6368:3: error: call to undeclared function 'wlr_keyboard_notify_modifiers'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
>  6368 |   wlr_keyboard_notify_modifiers(x0, x1, x2, x3, x4);

This function was added in #123, but include was forgotten.