### PR TITLE
Bindings for rendering from Python.

### DIFF
--- a/wlroots/renderer.py
+++ b/wlroots/renderer.py
@@ -86,6 +86,17 @@ class Renderer(Ptr):
             # TODO: get a better exception type
             raise Exception("Bad render")
 
+    def render_subtexture_with_matrix(
+        self, texture: Texture, box: Ptr, matrix: Matrix, alpha: float
+    ) -> None:
+        """Renders the requested subtexture using the provided matrix"""
+        ret = lib.wlr_render_subtexture_with_matrix(
+            self._ptr, texture._ptr, box, matrix._ptr, alpha
+        )
+        if not ret:
+            # TODO: get a better exception type
+            raise Exception("Bad render")
+
     def render_rect(self, box: Box, color: ColorType, projection: Matrix) -> None:
         """Renders a solid rectangle in the specified color."""
         if not isinstance(color, ffi.CData):

--- a/wlroots/util/box.py
+++ b/wlroots/util/box.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from pywayland.protocol.wayland import WlOutput
+
 from wlroots import ffi, lib
 
 
@@ -52,6 +54,15 @@ class Box:
     def __repr__(self) -> str:
         return f"Box({self.x}, {self.y}, {self.width}, {self.height})"
 
+    def copy(self) -> Box:
+        return Box(self.x, self.y, self.width, self.height)
+
+    def copy_from(self, other: Box) -> None:
+        self.x = other.x
+        self.y = other.y
+        self.width = other.width
+        self.height = other.height
+
     def closest_point(self, x: float, y: float) -> tuple[float, float]:
         xy_ptr = ffi.new("double[2]")
         lib.wlr_box_closest_point(self._ptr, x, y, xy_ptr, xy_ptr + 1)
@@ -59,3 +70,9 @@ class Box:
 
     def contains_point(self, x: float, y: float) -> bool:
         return lib.wlr_box_contains_point(self._ptr, x, y)
+
+    def transform(self, box: Box, transform: WlOutput.transform, width: int, height: int):
+        lib.wlr_box_transform(self._ptr, box._ptr, transform, width, height)
+
+    def intersection(self, box_a: Box, box_b: Box) -> bool:
+        return lib.wlr_box_intersection(self._ptr, box_a._ptr, box_b._ptr)

--- a/wlroots/util/region.py
+++ b/wlroots/util/region.py
@@ -51,6 +51,11 @@ class PixmanRegion32(Ptr):
             rects += 1
         return boxes
 
+    @property
+    def extents(self) -> Box:
+        rect = lib.pixman_region32_extents(self._ptr)
+        return Box(rect.x1, rect.y1, rect.x2 - rect.x1, rect.y2 - rect.y1)
+
     def transform(
         self,
         src: PixmanRegion32,
@@ -68,3 +73,71 @@ class PixmanRegion32(Ptr):
         Wrapper around pixman_region32_not_empty
         """
         return lib.pixman_region32_not_empty(self._ptr)
+
+    def intersect_rect(self, other: PixmanRegion32,
+                       x: int, y: int, width: int, height: int) -> bool:
+        """
+        Wrapper around pixman_region32_intersect_rect
+        """
+        return lib.pixman_region32_intersect_rect(self._ptr, other._ptr, x, y, width, height)
+
+    def union_rect(self, other: PixmanRegion32,
+                   x: int, y: int, width: int, height: int) -> bool:
+        """
+        Wrapper around pixman_region32_union_rect
+        """
+        return lib.pixman_region32_union_rect(self._ptr, other._ptr, x, y, width, height)
+
+    def intersect(self, reg1: PixmanRegion32, reg2: PixmanRegion32) -> bool:
+        """
+        Wrapper around pixman_region32_intersect
+        """
+        return lib.pixman_region32_intersect(self._ptr, reg1._ptr, reg2._ptr)
+
+    def union(self, reg1: PixmanRegion32, reg2: PixmanRegion32) -> bool:
+        """
+        Wrapper around pixman_region32_union
+        """
+        return lib.pixman_region32_union(self._ptr, reg1._ptr, reg2._ptr)
+
+    def subtract(self, reg1: PixmanRegion32, reg2: PixmanRegion32) -> bool:
+        """
+        Wrapper around pixman_region32_subtract
+        """
+        return lib.pixman_region32_subtract(self._ptr, reg1._ptr, reg2._ptr)
+
+    def copy_from(self, other: PixmanRegion32) -> bool:
+        """
+        Wrapper around pixman_region32_copy
+        """
+        return lib.pixman_region32_copy(self._ptr, other._ptr)
+
+    def translate(self, x: int, y: int) -> None:
+        """
+        Wrapper around pixman_region32_translate
+        """
+        lib.pixman_region32_translate(self._ptr, x, y)
+
+    def scale(self, other: PixmanRegion32, scale: float) -> None:
+        """
+        Wrapper around wlr_region_scale
+        """
+        lib.wlr_region_scale(self._ptr, other._ptr, scale)
+
+    def scale_xy(self, other: PixmanRegion32, scale_x: float, scale_y: float) -> None:
+        """
+        Wrapper around wlr_region_scale_xy
+        """
+        lib.wlr_region_scale_xy(self._ptr, other._ptr, scale_x, scale_y)
+
+    def expand(self, other: PixmanRegion32, distance: int) -> None:
+        """
+        Wrapper around wlr_region_expand
+        """
+        lib.wlr_region_expand(self._ptr, other._ptr, distance)
+
+    def clear(self) -> None:
+        """
+        Wrapper around pixman_region32_clear
+        """
+        lib.pixman_region32_clear(self._ptr)

--- a/wlroots/wlr_types/buffer.py
+++ b/wlroots/wlr_types/buffer.py
@@ -16,6 +16,14 @@ class Buffer(Ptr):
     def __init__(self, ptr) -> None:
         self._ptr = ptr
 
+    @property
+    def width(self) -> int:
+        return self._ptr.width;
+
+    @property
+    def height(self) -> int:
+        return self._ptr.height;
+
     def drop(self) -> None:
         """Destroys this wlr_texture."""
         lib.wlr_buffer_drop(self._ptr)

--- a/wlroots/wlr_types/scene.py
+++ b/wlroots/wlr_types/scene.py
@@ -5,14 +5,21 @@ from __future__ import annotations
 import enum
 from typing import TYPE_CHECKING, Callable, TypeVar
 
+from pywayland.protocol.wayland import WlOutput
+from pywayland.utils import wl_list_for_each, wl_container_of
+from pywayland.server import Signal
+
 from wlroots import Ptr, PtrHasData, ffi, lib
+from wlroots.util.box import Box
 from wlroots.util.region import PixmanRegion32
-from wlroots.wlr_types import Surface
+from wlroots.wlr_types import Surface, Buffer
+
+from .texture import Texture
 
 if TYPE_CHECKING:
-    from wlroots.util.box import Box
+    from typing import Iterator
     from wlroots.util.clock import Timespec
-    from wlroots.wlr_types import Buffer, Output, OutputLayout
+    from wlroots.wlr_types import Output, OutputLayout
     from wlroots.wlr_types.layer_shell_v1 import LayerSurfaceV1
     from wlroots.wlr_types.presentation_time import Presentation
     from wlroots.wlr_types.xdg_shell import XdgSurface
@@ -112,6 +119,14 @@ class SceneOutput(Ptr):
         """Set the output's position in the scene-graph."""
         lib.wlr_scene_output_set_position(self._ptr, lx, ly)
 
+    @property
+    def x(self):
+        return self._ptr.x
+
+    @property
+    def y(self):
+        return self._ptr.y
+
 
 class SceneTree(PtrHasData):
     def __init__(self, ptr) -> None:
@@ -123,6 +138,16 @@ class SceneTree(PtrHasData):
         """struct wlr_scene_tree"""
         ptr = ffi.addressof(self._ptr.node)
         return SceneNode(ptr)
+
+    @property
+    def children(self) -> Iterator[SceneNode]:
+        for ptr in wl_list_for_each(
+                "struct wlr_scene_node *",
+                self._ptr.children,
+                "link",
+                ffi=ffi
+        ):
+            yield SceneNode(ptr)
 
     @classmethod
     def create(cls, parent: SceneTree) -> SceneTree:
@@ -159,6 +184,32 @@ class SceneBuffer(Ptr):
         ptr = ffi.addressof(self._ptr.node)
         return SceneNode(ptr)
 
+    @property
+    def buffer(self) -> Buffer | None:
+        ptr = self._ptr.buffer
+        return Buffer(ptr) if ptr != ffi.NULL else None
+
+    @property
+    def texture(self) -> Texture | None:
+        ptr = self._ptr.texture
+        return Texture(ptr) if ptr != ffi.NULL else None
+
+    @texture.setter
+    def texture(self, texture: Texture | None):
+        self._ptr.texture = ffi.NULL if texture is None else texture._ptr
+
+    @property
+    def transform(self) -> WlOutput.transform:
+        return WlOutput.transform(self._ptr.transform)
+
+    @property
+    def dst_width(self) -> int:
+        return self._ptr.dst_width
+
+    @property
+    def dst_height(self) -> int:
+        return self._ptr.dst_height
+
     def set_buffer(self, buffer: Buffer | None) -> None:
         buffer_ptr = buffer._ptr if buffer else ffi.NULL
         lib.wlr_scene_buffer_set_buffer(self._ptr, buffer_ptr)
@@ -187,6 +238,7 @@ class SceneNode(PtrHasData):
     def __init__(self, ptr) -> None:
         """A node is an object in the scene."""
         self._ptr = ptr
+        self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
     @property
     def type(self) -> SceneNodeType:
@@ -207,8 +259,58 @@ class SceneNode(PtrHasData):
         return self._ptr.y
 
     @property
+    def visible(self) -> PixmanRegion32:
+        return PixmanRegion32(ffi.addressof(self._ptr.visible))
+
+    @property
+    def size(self) -> tuple[int, int]:
+        """Port of scene_node_get_size in wlr_scene.c."""
+        if self.type == SceneNodeType.RECT:
+            rect = self.as_rect
+            return rect.width, rect.height
+        if self.type == SceneNodeType.BUFFER:
+            scene_buffer = self.as_buffer
+            if scene_buffer.dst_width > 0 and scene_buffer.dst_height > 0:
+                return scene_buffer.dst_width, scene_buffer.dst_height
+            buffer = scene_buffer.buffer
+            if buffer:
+                if scene_buffer.transform & WlOutput.transform.transform_90:
+                    return buffer.height, buffer.width
+                else:
+                    return buffer.width, buffer.height
+        return 0, 0
+
+    @property
     def enabled(self) -> bool:
         return self._ptr.enabled
+
+    @property
+    def invisible(self) -> bool:
+        if self.type == SceneNodeType.TREE:
+            return True
+        elif self.type == SceneNodeType.RECT:
+            return self.as_rect.color[3] == 0.0
+        elif self.type == SceneNodeType.BUFFER:
+            return self.as_buffer.buffer is None
+        assert False
+
+    @property
+    def as_tree(self) -> SceneTree:
+        assert self.type == SceneNodeType.TREE
+        ptr = wl_container_of(self._ptr, "struct wlr_scene_tree *", "node", ffi=ffi)
+        return SceneTree(ptr)
+
+    @property
+    def as_rect(self) -> SceneRect:
+        assert self.type == SceneNodeType.RECT
+        ptr = wl_container_of(self._ptr, "struct wlr_scene_rect *", "node", ffi=ffi)
+        return SceneRect(ptr=ptr)
+
+    @property
+    def as_buffer(self) -> SceneBuffer:
+        assert self.type == SceneNodeType.BUFFER
+        ptr = wl_container_of(self._ptr, "struct wlr_scene_buffer *", "node", ffi=ffi)
+        return SceneBuffer(ptr)
 
     def destroy(self) -> None:
         """Immediately destroy the scene-graph node."""
@@ -273,6 +375,17 @@ class SceneNode(PtrHasData):
             self._ptr, lib.buffer_iterator_callback, handle
         )
 
+    def coords(self) -> tuple[bool, int, int]:
+        """Get the node's layout-local coordinates.
+
+        The first entry of the return value is True if the node and all of its
+        ancestors are enabled.
+        """
+        x_ptr = ffi.new("int *")
+        y_ptr = ffi.new("int *")
+        enabled = lib.wlr_scene_node_coords(self._ptr, x_ptr, y_ptr)
+        return enabled, x_ptr[0], y_ptr[0]
+
 
 class SceneSurface(Ptr):
     def __init__(self, ptr) -> None:
@@ -293,16 +406,36 @@ class SceneSurface(Ptr):
 
 class SceneRect(Ptr):
     def __init__(
-        self, parent: SceneTree, width: int, height: int, color: ffi.CData
+            self,
+            parent: SceneTree | None = None,
+            width: int | None = None,
+            height: int | None = None,
+            color: ffi.CData | None = None,
+            ptr = None,
     ) -> None:
         """A scene-graph node displaying a solid-colored rectangle"""
-        self._ptr = lib.wlr_scene_rect_create(parent._ptr, width, height, color)
+        if ptr is None:
+            ptr = lib.wlr_scene_rect_create(parent._ptr, width, height, color)
+        self._ptr = ptr
 
     @property
     def node(self) -> SceneNode:
         """struct wlr_scene_tree"""
         ptr = ffi.addressof(self._ptr.node)
         return SceneNode(ptr)
+
+    @property
+    def width(self) -> int:
+        return self._ptr.width
+
+    @property
+    def height(self) -> int:
+        return self._ptr.height
+
+    @property
+    def color(self) -> tuple[int, int, int, int]:
+        c = self._ptr.color
+        return c[0], c[1], c[2], c[3]
 
     def set_size(self, width: int, height: int) -> None:
         """Change the width and height of an existing rectangle node."""

--- a/wlroots/wlr_types/texture.py
+++ b/wlroots/wlr_types/texture.py
@@ -51,6 +51,14 @@ class Texture(Ptr):
         ptr = ffi.gc(ptr, lib.wlr_texture_destroy)
         return Texture(ptr)
 
+    @property
+    def width(self):
+        return self._ptr.width
+
+    @property
+    def height(self):
+        return self._ptr.height
+
     def update_from_buffer(
         self,
         buffer: Buffer,


### PR DESCRIPTION
I'm writing a custom scene graph renderer for qtile: https://github.com/qtile/qtile/discussions/4553

These are some straightforward bindings that I found I needed.  Most of them are in scene.py, although I also added some low-level bindings to `wlr/renderer/egl.h` and `wlr/renderer/gles2.h`.