### PR TITLE
Change some exceptions to return values

### DIFF
--- a/wlroots/backend.py
+++ b/wlroots/backend.py
@@ -72,20 +72,19 @@ class Backend(Ptr):
 
             self._ptr = None
 
-    def start(self) -> None:
+    def start(self) -> bool:
         """Start the backend
 
         This may signal new_input or new_output immediately, but may also wait
         until the display's event loop begins.
         """
-        ret = lib.wlr_backend_start(self._ptr)
-        if not ret:
-            self.destroy()
-            raise RuntimeError("Unable to start backend")
+        return lib.wlr_backend_start(self._ptr)
 
     def __enter__(self) -> Backend:
         """Context manager to create and clean-up the backend"""
-        self.start()
+        if not self.start():
+            self.destroy()
+            raise RuntimeError("Unable to start backend")
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb) -> None:

--- a/wlroots/wlr_types/output.py
+++ b/wlroots/wlr_types/output.py
@@ -160,9 +160,6 @@ class Output(PtrHasData):
     def __exit__(self, exc_type, exc_value, exc_tb) -> None:
         """Stop rendering frame, commit when exiting normally, otherwise rollback"""
         if exc_type is None:
-            if not self.test():
-                self.rollback()
-                raise RuntimeError("Rendering on output failed")
             if not self.commit():
                 raise RuntimeError("Unable to commit output")
         else:

--- a/wlroots/wlr_types/output.py
+++ b/wlroots/wlr_types/output.py
@@ -160,7 +160,11 @@ class Output(PtrHasData):
     def __exit__(self, exc_type, exc_value, exc_tb) -> None:
         """Stop rendering frame, commit when exiting normally, otherwise rollback"""
         if exc_type is None:
-            self.commit()
+            if not self.test():
+                self.rollback()
+                raise RuntimeError("Rendering on output failed")
+            if not self.commit():
+                raise RuntimeError("Unable to commit output")
         else:
             self.rollback()
 
@@ -187,17 +191,13 @@ class Output(PtrHasData):
         if not lib.wlr_output_attach_render(self._ptr, ffi.NULL):
             raise RuntimeError("Unable to attach render")
 
-    def commit(self) -> None:
+    def commit(self) -> bool:
         """Commit the pending output state
 
         If `.attach_render` has been called, the pending frame will be
         submitted for display.
         """
-        if not lib.wlr_output_test(self._ptr):
-            self.rollback()
-            raise RuntimeError("Rendering on output failed")
-        if not lib.wlr_output_commit(self._ptr):
-            raise RuntimeError("Unable to commit output")
+        return lib.wlr_output_commit(self._ptr)
 
     def rollback(self) -> None:
         """Discard the pending output state"""


### PR DESCRIPTION
Modify `Backend.start` and `Output.commit` to return boolean values rather than checking the return value and raising an error. Move the logic for the Pythonic APIs into the Python-specific functions, in particular the `__enter__` and `__exit__` so these objects will be well behaved when using the context manager.

Closes #135
Closes #136