### PR TITLE
Removed Seat property "has_grab" in favour of more explicit methods.

### DIFF
--- a/wlroots/wlr_types/seat.py
+++ b/wlroots/wlr_types/seat.py
@@ -256,11 +256,6 @@ class Seat(PtrHasData):
         """Start a grab of the keyboard of this seat"""
         return KeyboardGrab(self)
 
-    @property
-    def has_grab(self) -> bool:
-        """Whether or not the keyboard has a grab other than the default grab"""
-        return lib.wlr_seat_keyboard_has_grab(self._ptr)
-
     def keyboard_notify_key(self, key_event: KeyboardKeyEvent) -> None:
         """Notify the seat that a key has been pressed on the keyboard
 


### PR DESCRIPTION
The property "has_grab" mirrors the method "keyboard_has_grab", but since there are several "_has_grab" functions, the user should call the specific method.

Fixes #147