### PR TITLE
Added support for the Single-pixel buffer protocol.

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -2226,6 +2226,12 @@ void wlr_server_decoration_manager_set_default_mode(
     struct wlr_server_decoration_manager *manager, uint32_t default_mode);
 """
 
+# types/wlr_single_pixel_buffer_v1.h
+CDEF += """
+struct wlr_single_pixel_buffer_manager_v1 *wlr_single_pixel_buffer_manager_v1_create(
+    struct wl_display *display);
+"""
+
 # types/wlr_touch.h
 CDEF += """
 struct wlr_touch {
@@ -2891,6 +2897,7 @@ SOURCE = """
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_server_decoration.h>
+#include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>

--- a/wlroots/wlr_types/single_pixel_buffer_v1.py
+++ b/wlroots/wlr_types/single_pixel_buffer_v1.py
@@ -1,0 +1,22 @@
+from pywayland.server import Display
+
+from wlroots import Ptr, lib
+
+
+class SinglePixelBufferManagerV1(Ptr):
+    """Global factory for single-pixel buffers.
+
+    This protocol extension allows clients to create single-pixel buffers.
+
+    Compositors supporting this protocol extension should also support the
+    viewporter protocol extension (see wlr_types.viewporter.Viewporter).
+
+    Clients may use viewporter to scale a single-pixel buffer to a desired size.
+    """
+
+    def __init__(self, display: Display) -> None:
+        """Binds the manager to the provided display.
+
+        :param display: The wayland display
+        """
+        self._ptr = lib.wlr_single_pixel_buffer_manager_v1_create(display._ptr)


### PR DESCRIPTION
Added wlr_types/single_pixel_buffer_v1 to support the single-pixel buffer protocol (part of wlroots since 0.16.0).

Fixes #155.