### PR TITLE
SceneOutput.commit: Replaced exception with boolean value

### DIFF
--- a/wlroots/wlr_types/scene.py
+++ b/wlroots/wlr_types/scene.py
@@ -90,10 +90,9 @@ class SceneOutput(Ptr):
         """
         return cls(lib.wlr_scene_output_create(scene._ptr, output._ptr))
 
-    def commit(self) -> None:
+    def commit(self) -> bool:
         """Render and commit an output."""
-        if not lib.wlr_scene_output_commit(self._ptr):
-            raise RuntimeError("Unable to commit scene output")
+        return lib.wlr_scene_output_commit(self._ptr)
 
     def destroy(self) -> None:
         """Destroy a scene-graph output."""


### PR DESCRIPTION
Removed the RuntimeException in SceneOutput.commit() since it is a non-critical error. The boolean value should be sufficient and is closer to the wlroots API.

Closes #164.