### PR TITLE
XdgTopLevel: Don't check parent pointer against None but ffi.NULL

### DIFF
--- a/wlroots/wlr_types/xdg_shell.py
+++ b/wlroots/wlr_types/xdg_shell.py
@@ -276,7 +276,7 @@ class XdgTopLevel(Ptr):
     def parent(self) -> XdgTopLevel | None:
         """The parent of this toplevel"""
         parent_ptr = self._ptr.parent
-        if parent_ptr is None:
+        if parent_ptr == ffi.NULL:
             return None
         return XdgTopLevel(parent_ptr)
 


### PR DESCRIPTION
XdgTopLevel.parent returned always a parent even if the underlying _ptr.parent refers to NULL.
Replaced the check against None with a check against ffi.NULL.

Closes #183.