### PR TITLE
Fixed signature of Seat.touch_point_clear_focus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+0.16.9 -- 2024-mm-dd
+--------------------
+* Fixed ``Seat.touch_point_clear_focus``: The method took too many arguments
+  which were not aligned to the wlroots counterpart and lead to a runtime error.
+* This is probably the last 0.16 release unless there are important bugs to fix.
+  Since Linux distributions are phasing out support for wlroots 0.16, projects
+  should move to pywlroots 0.17 once this version is released
+
+
 0.16.8 -- 2024-05-04
 --------------------
 * Fixed: ``XdgTopLevel.parent`` always returnd a parent even if the parent is NULL.

--- a/wlroots/wlr_types/seat.py
+++ b/wlroots/wlr_types/seat.py
@@ -400,16 +400,11 @@ class Seat(PtrHasData):
 
     def touch_point_clear_focus(
         self,
-        surface: Surface,
         time_msec: int,
         touch_id: int,
-        surface_x: float,
-        surface_y: float,
     ) -> None:
         """Clear the focused surface for the touch point given by `touch_id`."""
-        lib.wlr_seat_touch_point_clear_focus(
-            self._ptr, surface._ptr, time_msec, touch_id, surface_x, surface_y
-        )
+        lib.wlr_seat_touch_point_clear_focus(self._ptr, time_msec, touch_id)
 
     def touch_notify_cancel(self, surface: Surface):
         """Notify the seat that this is a global gesture and the client should


### PR DESCRIPTION
touch_point_clear_focus took too many arguments like ``surface`` and the surface coordinates. Aligned the signature to wlr_seat_touch_point_clear_focus.

Closes #189