### PR TITLE
fixes for ext-session-lock-v1

### DIFF
--- a/wlroots/ffi_build.py
+++ b/wlroots/ffi_build.py
@@ -2263,6 +2263,7 @@ struct wlr_session_lock_v1 {
     } events;
 
     void *data;
+    ...;
 };
 
 struct wlr_session_lock_surface_v1_state {

--- a/wlroots/wlr_types/session_lock_v1.py
+++ b/wlroots/wlr_types/session_lock_v1.py
@@ -65,7 +65,6 @@ class SessionLockSurfaceV1(PtrHasData):
 
     def __init__(self, ptr) -> None:
         self._ptr = ffi.cast("struct wlr_session_lock_surface_v1 *", ptr)
-        self.map_event = Signal(ptr=ffi.addressof(self._ptr.events.map))
         self.destroy_event = Signal(ptr=ffi.addressof(self._ptr.events.destroy))
 
     @property


### PR DESCRIPTION
I'm currently looking into ext-session-lock-v1 support in the Qtile wlroots backend. (still work in progress)

The corresponding exceptions I got were:

```
Exception ignored from cffi callback <function notify_func at 0x7a8e6db49760>:
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/pywayland/server/listener.py", line 35, in notify_func
    data = listener._signal._data_wrapper(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/wlroots/wlr_types/session_lock_v1.py", line 48, in __init__
    ptr=ffi.addressof(self._ptr.events.new_surface),
                      ^^^^^^^^^^^^^^^^
ffi.error: struct wlr_session_lock_v1: wrong total size (cdef says 80, but C compiler says 88). fix it or use "...;" as the last field in the cdef for struct wlr_session_lock_v1 to make it flexible
```
and

```
Exception ignored from cffi callback <function notify_func at 0x783935ba5760>:
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/pywayland/server/listener.py", line 35, in notify_func
    data = listener._signal._data_wrapper(data) 
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/wlroots/wlr_types/session_lock_v1.py", line 68, in __init__
    self.map_event = Signal(ptr=ffi.addressof(self._ptr.events.map))
                                              ^^^^^^^^^^^^^^^^^^^^
AttributeError: cdata 'struct $46' has no field 'map'
```

