### PR TITLE
fix: remove pypy in python version 3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
         pypy-version: ["7.3"]
     steps:
       - name: Download wayland libraries
@@ -281,7 +281,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "pypy-3.9"
           - "pypy-3.10"
     steps:
       - name: Install dependencies


### PR DESCRIPTION
I was testing the workflows the other day and realize that pypy 3.9 was always failing. I did a research and found out that support for 3.9 was drop. See [PyPy anouncement](https://doc.pypy.org/en/latest/release-v7.3.17.html#pypy-versions-and-speed-pypy-org) and [manylinux anouncement](https://github.com/pypa/manylinux/issues/1680).