### PR TITLE
expose xwayland.Server's pid

### DIFF
--- a/wlroots/xwayland.py
+++ b/wlroots/xwayland.py
@@ -75,6 +75,10 @@ class Server(PtrHasData):
     def ready(self) -> bool:
         return self._ptr.ready
 
+    @property
+    def pid(self) -> int:
+        return self._ptr.pid
+
 
 class XWayland(PtrHasData):
     def __init__(self, display: Display, compositor: Compositor, lazy: bool) -> None:


### PR DESCRIPTION
wlroots wants to fork() and waitpid() on the result:

https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/871646d22522141c45db2c0bfa1528d595bb69df

(this code *almost* does the right thing, but only does SIG_BLOCK in the first fork, not the parent...)

applications using wlroots which have SIGCHLD handlers installed may interfere with this, so expose the server pid so they can use WNOWAIT trickery to avoid reaping this pid, to allow wlroots to do so.

Maybe this is the wrong patch to fix the described issue: maybe pywayland should block SIGCHLD (via signal.pthread_sigmask(), since applications may be multithreaded, especially if they use asyncio) and then do wlr_xwayland_server_create(), then unblock it for users? But either way, seems like people might want to see the pid here.