### PR TITLE
fix: xkbcommon error

### DIFF
--- a/dist-build-constraints.txt
+++ b/dist-build-constraints.txt
@@ -1,1 +1,1 @@
-xkbcommon<1.5
+xkbcommon<1.0


### PR DESCRIPTION
This is a version problem, manylinux_2_28 is based on AlmaLinux 8 ([reference](https://github.com/pypa/manylinux/blob/main/README.rst#manylinux_2_28-almalinux-8-based)).

AlmaLinux 8 uses version 0.9 for libxkbcommon ([reference](https://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/Packages/)) which is lower than the target version of python-xkbcommon which is 1.0.1