### PR TITLE
fix tinywl popup handling

### DIFF
--- a/tiny/server.py
+++ b/tiny/server.py
@@ -339,6 +339,7 @@ class TinywlServer:
         assert xdg_surface.role == XdgSurfaceRole.TOPLEVEL
 
         scene_tree = Scene.xdg_surface_create(self._scene.tree, xdg_surface)
+        xdg_surface.data = scene_tree
         view = View(xdg_surface, self, scene_tree.node)
         self.views.append(view)
 


### PR DESCRIPTION
The data field is not being set for toplevels, so when it needs to be accessed for popup handling, an error occurs. This pull request adds a line to set the data field for toplevels, preventing the error.