### PR TITLE
fix: libdrm repository name change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     container: quay.io/pypa/manylinux_2_34_x86_64
     env:
-      libdrm-version: "2.4.119"
+      libdrm-version: "2.4.121"
       seatd-version: "0.6.3"
       pixman-version: "0.42.0"
       xwayland-version: "22.1.9"
@@ -72,7 +72,7 @@ jobs:
           tar -xzf xorgproto-xorgproto-${{ env.inputproto-version }}.tar.gz
           tar -xzf libxcvt-libxcvt-${{ env.xcvt-version }}.tar.gz
           tar -xzf xserver-xwayland-${{ env.xwayland-version }}.tar.gz
-          tar -xzf drm-libdrm-${{ env.libdrm-version }}.tar.gz
+          tar -xzf libdrm-libdrm-${{ env.libdrm-version }}.tar.gz
           tar -xjf pixman-pixman-${{ env.pixman-version }}.tar.bz2
           tar -xzf seatd.tar.gz
           tar -xzf wlroots.tar.gz
@@ -82,7 +82,7 @@ jobs:
           XWAYLAND_URL: https://gitlab.freedesktop.org/xorg/xserver/-/archive/xwayland-${{ env.xwayland-version }}/xserver-xwayland-${{ env.xwayland-version }}.tar.gz
           XCVT_URL: https://gitlab.freedesktop.org/xorg/lib/libxcvt/-/archive/libxcvt-${{ env.xcvt-version }}/libxcvt-libxcvt-${{ env.xcvt-version }}.tar.gz
           INPUTPROTO_URL: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/archive/xorgproto-${{ env.inputproto-version}}/xorgproto-xorgproto-${{ env.inputproto-version}}.tar.gz
-          LIBDRM_URL: https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${{ env.libdrm-version }}/drm-libdrm-${{ env.libdrm-version }}.tar.gz
+          LIBDRM_URL: https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-${{ env.libdrm-version }}/libdrm-libdrm-${{ env.libdrm-version }}.tar.gz
           SEATD_URL: https://git.sr.ht/~kennylevinsen/seatd/archive/${{ env.seatd-version }}.tar.gz
           PIXMAN_URL: https://gitlab.freedesktop.org/pixman/pixman/-/archive/pixman-${{ env.pixman-version }}/pixman-pixman-${{ env.pixman-version }}.tar.bz2
           WLROOTS_URL: https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/${{ env.wlroots-version }}/wlroots-${{ env.wlroots-version }}.tar.gz
@@ -104,7 +104,7 @@ jobs:
           DESTDIR=~/wayland ninja -C build install
           ninja -C build install
       - name: Build libdrm
-        working-directory: drm-libdrm-${{ env.libdrm-version }}
+        working-directory: libdrm-libdrm-${{ env.libdrm-version }}
         run: |
           meson build --prefix=/usr
           ninja -C build


### PR DESCRIPTION
This fixes the gitlab repository name change and the new minimum version required of libdrm.