### PR TITLE
fix: use SPDX license expression, avoid deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=62.4.0",
+    "setuptools>=77.0.0",
     "wheel",
     "cffi>=1.12.0; platform_python_implementation != 'PyPy'",
 ]
@@ -11,7 +11,7 @@ name = "pywlroots"
 description = "Python binding to the wlroots library using cffi"
 authors = [{name = "Sean Vig", email = "sean.v.775@gmail.com"}]
 requires-python = ">=3.9"
-license = {text = "University of Illinois/NCSA Open Source License"}
+license = "NCSA"
 readme = "README.rst"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
See warning:
```
/usr/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
```