### PR TITLE
fix: explicit destroy, prevent segmentation fault

### DIFF
--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -6,4 +6,5 @@ from wlroots.helper import build_compositor
 
 def test_build_compositor():
     with Display() as display:
-        build_compositor(display, backend_type=BackendType.HEADLESS)
+        _, _, _, backend, _ = build_compositor(display, backend_type=BackendType.HEADLESS)
+        backend.destroy()


### PR DESCRIPTION
See error in tests:
```
============================= test session starts ==============================
platform linux -- Python 3.11.11[pypy-7.3.19-final], pytest-8.4.0, pluggy-1.6.0
rootdir: /home/runner/work/pywlroots/pywlroots
configfile: pyproject.toml
collected 5 items

tests/test_display.py ..                                                 [ 40%]
tests/test_helper.py .                                                   [ 60%]
/home/runner/work/_temp/fd0cac54-07c7-40e3-ad12-9e63e6284282.sh: line 1:  4639 Segmentation fault      (core dumped) pytest -Wall
tests/test_wlroots.py ..                                                 [100%]
Error: Process completed with exit code 139.
```