### PR TITLE
fix(ci): do not use master, always failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wlroots-version: ["0.17.4", master]
+        wlroots-version: ["0.17.4"]
     steps:
       - name: Install dependencies
         run: |
@@ -90,7 +90,6 @@ jobs:
           sudo ninja -C build install
       - name: Build wlroots
         working-directory: wlroots-${{ matrix.wlroots-version }}
-        continue-on-error: ${{ matrix.wlroots-version == 'master' }}
         run: |
           meson build --prefix=/usr -Dxwayland=enabled
           ninja -C build
@@ -104,7 +103,7 @@ jobs:
           path: ~/wayland.tar.gz
           if-no-files-found: error
   unit-test:
-    name: Python ${{ matrix.python-version}} unit tests (${{ matrix.wlroots-version }})
+    name: Python ${{ matrix.python-version}} unit tests
     runs-on: ubuntu-24.04
     needs: build-wayland
     strategy:
@@ -118,9 +117,6 @@ jobs:
           - "3.13"
           - "pypy-3.11"
         wlroots-version: ["0.17.4"]
-        include:
-          - python-version: "3.13"
-            wlroots-version: master
     steps:
       - name: Download wayland libraries
         uses: actions/download-artifact@v4
@@ -174,11 +170,9 @@ jobs:
         run: |
           echo "XDG_RUNTIME_DIR=/tmp" >> $GITHUB_ENV
       - name: Install Python dependencies
-        continue-on-error: ${{ matrix.wlroots-version == 'master' }}
         run: |
           pip install -e .[test]
       - name: Run unit tests
-        continue-on-error: ${{ matrix.wlroots-version == 'master' }}
         run: pytest -Wall
         env:
           WLR_HEADLESS_OUTPUTS: '1'


### PR DESCRIPTION
As of now, the master branch is too ahead of development that compiling is never successful and incompatible with pywlroots version. Even versions between wlroots are not compatible with each other, that why each have their own directory now.

```
/usr/include/wlroots-0.18/
/usr/include/wlroots-0.19/
```

Targeting a release like `0.18.2` or `0.19.0` would be better than trying `master`.