### PR TITLE
fix: avoid deleting files in setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,12 @@ line-length = 88
 [tool.black]
 line-length = 88
 
+[tool.check-manifest]
+ignore = [
+    "wlroots/_build.py",
+    "wlroots/include/*.h",
+]
+
 [tool.mypy]
 check_untyped_defs = true
 # disallow_any_decorated = true

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,13 @@
 # Copyright (c) Sean Vig 2018
 
-import glob
-import os
 import subprocess
 import sys
 
 from setuptools import setup
-from setuptools.command.sdist import sdist
-
-
-class SdistClean(sdist):
-    def run(self):
-        # These files are not tracked by git and as a result check-manifest complains
-        # when present, '_build.py' needs to be removed manually since it keeps being
-        # created by other setup commands and '.h' files are needen only during build
-        files = glob.glob("wlroots/include/*.h")
-        files.append("wlroots/_build.py")
-        for file in files:
-            try:
-                os.remove(file)
-            except Exception:
-                pass
-        sdist.run(self)
-
 
 sys.path.insert(0, "wlroots")
 
 subprocess.run(["python", "wlroots/include/check_headers.py", "--generate"])
 setup(
-    cmdclass={"sdist": SdistClean},
     cffi_modules=["wlroots/ffi_build.py:ffi_builder"],
 )


### PR DESCRIPTION
I learned this from developing in pywayland, this should be better than the patch I introduce to remove created files in `setup.py`. 